### PR TITLE
Replace references of dls-controls with epics-containers for repo migration

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Publish Docs to gh-pages
         # Only master and tags are published
-        if: "${{ github.repository_owner == 'dls-controls' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}"
+        if: "${{ github.repository_owner == 'epics-containers' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}"
         # We pin to the SHA, not the tag, for security reasons.
         # https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
         uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501 # v3.7.3

--- a/.gitremotes
+++ b/.gitremotes
@@ -1,1 +1,1 @@
-github git@github.com:dls-controls/ibek.git
+github git@github.com:epics-containers/ibek.git

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,5 +13,5 @@ Unreleased_
 Nothing yet
 
 
-.. _Unreleased: https://github.com/dls-controls/ibek/compare/0.1...HEAD
-.. _0.1: https://github.com/dls-controls/ibek/releases/tag/0.1
+.. _Unreleased: https://github.com/epics-containers/ibek/compare/0.1...HEAD
+.. _0.1: https://github.com/epics-containers/ibek/releases/tag/0.1

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -2,13 +2,13 @@ Contributing
 ============
 
 Contributions and issues are most welcome! All issues and pull requests are
-handled through github on the `dls_controls repository`_. Also, please check for
+handled through github on the `epics-containers repository`_. Also, please check for
 any existing issues before filing a new one. If you have a great idea but it
 involves big changes, please file a ticket before making a pull request! We
 want to make sure you don't spend your time coding something that might not fit
 the scope of the project.
 
-.. _dls_controls repository: https://github.com/epics-containers/ibek/issues
+.. _epics-containers repository: https://github.com/epics-containers/ibek/issues
 
 Running the tests
 -----------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -8,14 +8,14 @@ involves big changes, please file a ticket before making a pull request! We
 want to make sure you don't spend your time coding something that might not fit
 the scope of the project.
 
-.. _dls_controls repository: https://github.com/dls-controls/ibek/issues
+.. _dls_controls repository: https://github.com/epics-containers/ibek/issues
 
 Running the tests
 -----------------
 
 To get the source source code and run the unit tests, run::
 
-    $ git clone git://github.com/dls-controls/ibek.git
+    $ git clone git://github.com/epics-containers/ibek.git
     $ cd ibek
     $ pipenv install --dev
     $ pipenv run tests

--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,9 @@ IOC Builder for EPICS and Kubernetes:
 
 ============== ==============================================================
 PyPI           ``pip install ibek``
-Source code    https://github.com/dls-controls/ibek
-Documentation  https://dls-controls.github.io/ibek
-Changelog      https://github.com/dls-controls/ibek/blob/master/CHANGELOG.rst
+Source code    https://github.com/epics-containers/ibek
+Documentation  https://epics-containers.github.io/ibek
+Changelog      https://github.com/epics-containers/ibek/blob/master/CHANGELOG.rst
 ============== ==============================================================
 
 TODO
@@ -63,16 +63,16 @@ This project is incomplete. The following items are still to do:
     - Add a diagram and more details. Use draw.io for image, and save as SVG
       with source embed in it, save as something.draw.io.svg
 
-.. |code_ci| image:: https://github.com/dls-controls/ibek/workflows/Code%20CI/badge.svg?branch=master
-    :target: https://github.com/dls-controls/ibek/actions?query=workflow%3A%22Code+CI%22
+.. |code_ci| image:: https://github.com/epics-containers/ibek/workflows/Code%20CI/badge.svg?branch=master
+    :target: https://github.com/epics-containers/ibek/actions?query=workflow%3A%22Code+CI%22
     :alt: Code CI
 
-.. |docs_ci| image:: https://github.com/dls-controls/ibek/workflows/Docs%20CI/badge.svg?branch=master
-    :target: https://github.com/dls-controls/ibek/actions?query=workflow%3A%22Docs+CI%22
+.. |docs_ci| image:: https://github.com/epics-containers/ibek/workflows/Docs%20CI/badge.svg?branch=master
+    :target: https://github.com/epics-containers/ibek/actions?query=workflow%3A%22Docs+CI%22
     :alt: Docs CI
 
-.. |coverage| image:: https://codecov.io/gh/dls-controls/ibek/branch/master/graph/badge.svg
-    :target: https://codecov.io/gh/dls-controls/ibek
+.. |coverage| image:: https://codecov.io/gh/epics-containers/ibek/branch/master/graph/badge.svg
+    :target: https://codecov.io/gh/epics-containers/ibek
     :alt: Test Coverage
 
 .. |pypi_version| image:: https://img.shields.io/pypi/v/ibek.svg
@@ -87,4 +87,4 @@ This project is incomplete. The following items are still to do:
     Anything below this line is used when viewing README.rst and will be replaced
     when included in index.rst
 
-See https://dls-controls.github.io/ibek for more detailed documentation.
+See https://epics-containers.github.io/ibek for more detailed documentation.

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -11,7 +11,7 @@
   <!-- https://stackoverflow.com/a/37843854 -->
   <a href="{{ pathto('genindex.html', 1) }}">Index</a>
   <!-- Include link to changelog -->
-  <a href="https://github.com/dls-controls/{{ project }}/blob/master/CHANGELOG.rst">Changelog</a>
+  <a href="https://github.com/epics-containers/{{ project }}/blob/master/CHANGELOG.rst">Changelog</a>
   <!-- Add versions for selected branches + tags -->
   <p class="caption"><span class="caption-text">Versions</span></p>
   <ul id="versions"/>
@@ -24,7 +24,7 @@
       if (dirs.has(name)) {
         var li = document.createElement("li");
         var a = document.createElement("a");
-        a.href = 'https://dls-controls.github.io/{{ project }}/' + name;
+        a.href = 'https://epics-containers.github.io/{{ project }}/' + name;
         a.innerText = name;
         li.appendChild(a)
         document.getElementById('versions').appendChild(li);
@@ -32,13 +32,13 @@
     }
     Promise.all([
       // Find gh-pages directories and populate `dirs`
-      fetch("https://api.github.com/repos/dls-controls/{{ project }}/contents?ref=gh-pages")
+      fetch("https://api.github.com/repos/epics-containers/{{ project }}/contents?ref=gh-pages")
       .then(response => response.json())
       .then(data => data.forEach(function(e) {
         if (e.type == "dir") dirs.add(e.name);
       })),
       // Add tags to `versions`
-      fetch('https://api.github.com/repos/dls-controls/{{ project }}/tags')
+      fetch('https://api.github.com/repos/epics-containers/{{ project }}/tags')
         .then(response => response.json())
         .then(data => data.forEach(function(e) {
           versions.push(e.name);

--- a/docs/tutorials/installation.rst
+++ b/docs/tutorials/installation.rst
@@ -35,7 +35,7 @@ You can now use ``pip`` to install the library::
 If you require a feature that is not currently released you can also install
 from github::
 
-    python3 -m pip install git+git://github.com/dls-controls/ibek.git
+    python3 -m pip install git+git://github.com/epics-containers/ibek.git
 
 The library should now be installed and the commandline interface on your path.
 You can check the version that has been installed by typing::

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = ibek
 description = IOC Builder for EPICS and Kubernetes
-url = https://github.com/dls-controls/ibek
+url = https://github.com/epics-containers/ibek
 author = Tom Cobb
 author_email = tom.cobb@diamond.ac.uk
 license = Apache License 2.0


### PR DESCRIPTION
These should be all the changes to get docs building and linking correctly.