### PR TITLE
Feature/entity disabled

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -2,6 +2,11 @@ name: Code CI
 
 on:
   push:
+    branches:
+      - master
+      - main
+    tags:
+      - "*"
   pull_request:
 
 jobs:
@@ -9,31 +14,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest"] # can add windows-latest, macos-latest
+        os: ["ubuntu-latest"]  # can add windows-latest, macos-latest
         python: ["3.7", "3.8", "3.9"]
+        pipenv: ["skip-lock"]  # --${flag} will be passed to pipenv command
 
         include:
-          # Tag the Python3.7 runner as the one to publish wheels
+          # Add an extra Python3.7 runner to publish wheels and use the lockfile
           - os: "ubuntu-latest"
             python: "3.7"
+            pipenv: "deploy"
             publish: true
 
-    name: build/${{ matrix.python }}/${{ matrix.os }}
+    name: build/${{ matrix.python }}/${{ matrix.os }}/${{ matrix.pipenv }}
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout Source
         uses: actions/checkout@v2
+        with:
+          # require history to get back to last tag for version number of branches
+          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
-
-      - name: Install Python Dependencies
-        run: |
-          pip install pipenv build
-          pipenv install --dev --deploy --python $(python -c 'import sys; print(sys.executable)') && pipenv graph
 
       - name: Create Sdist and Wheel
         if: matrix.publish
@@ -43,15 +48,28 @@ jobs:
         run: |
           chmod -R g+w .
           umask 0002
-          SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) python -m build --sdist --wheel
+          SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) pipx run build --sdist --wheel
+      - name: Test cli works from the installed wheel
+        if: matrix.publish
+        # Can remove the repository reference after https://github.com/pypa/pipx/pull/733
+        run: pipx run --spec dist/*.whl ${GITHUB_REPOSITORY##*/} --version
 
+      - name: Use a non-editable install to test the installed wheel
+        if: matrix.pipenv == 'skip-lock'
+        run: sed -i 's/editable *= *true/editable = false/' Pipfile
+
+      - name: Install Python Dependencies
+        run: |
+          pip install pipenv
+          pipenv install --dev --${{ matrix.pipenv }} --python $(python -c 'import sys; print(sys.executable)') && pipenv graph
       - name: Run Tests
-        run: pipenv run tests
+        # https://github.com/pytest-dev/pytest/issues/2042
+        run: PY_IGNORE_IMPORTMISMATCH=1 pipenv run tests
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
-          name: ${{ matrix.python }}/${{ matrix.os }}
+          name: ${{ toJSON(matrix) }}
           files: cov.xml
 
       - name: Upload Wheel and Sdist as artifacts
@@ -75,7 +93,7 @@ jobs:
       - name: Github Release
         # We pin to the SHA, not the tag, for security reasons.
         # https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
-        uses: softprops/action-gh-release@2d72d869af3bf23602f9593a1e3fd739b80ac1eb # v0.1.12
+        uses: softprops/action-gh-release@2d72d869af3bf23602f9593a1e3fd739b80ac1eb  # v0.1.12
         with:
           files: dist/*
           body: See [Changelog](CHANGELOG.rst) for more details

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,10 +2,17 @@ name: Docs CI
 
 on:
   push:
+    branches:
+      # Add more branches here to publish docs from other branches
+      - master
+      - main
+    tags:
+      - "*"
   pull_request:
 
 jobs:
   build:
+    name: "Docs CI"
     runs-on: ubuntu-latest
 
     steps:
@@ -20,30 +27,29 @@ jobs:
         with:
           python-version: "3.7"
 
+      - name: Install Packages
+        run: sudo apt-get install graphviz
+
       - name: Install Python Dependencies
         run: |
           pip install pipenv
           pipenv install --dev --deploy --python $(which python) && pipenv graph
-
       - name: Build Docs
         run: pipenv run docs
 
-      - uses: rishabhgupta/split-by@v1
-        id: split
-        with:
-          string: ${{ github.ref }}
-          split-by: /
-
       - name: Move to versioned directory
         # e.g. master or 0.1.2
-        run: mv build/html ".github/pages/${{ steps.split.outputs._2 }}"
+        run: mv build/html ".github/pages/${GITHUB_REF##*/}"
+
+      - name: Avoid git conflicts when tag and branch pushed at same time
+        if: startsWith(github.ref, 'refs/tags')
+        run: sleep 60
 
       - name: Publish Docs to gh-pages
-        # Only master and tags are published
-        if: "${{ github.repository_owner == 'epics-containers' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}"
+        if: github.event_name == 'push'
         # We pin to the SHA, not the tag, for security reasons.
         # https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
-        uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501 # v3.7.3
+        uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305  # v3.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: .github/pages

--- a/Pipfile
+++ b/Pipfile
@@ -4,33 +4,12 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-# Pinning black stops us having to allow pre-releases globally
-black = "==19.10b0"
-# Flake version 4.0 and 4.0.1 do not like pytest: https://github.com/tholo/pytest-flake8/issues/81
-flake8 = "==3.9.2"
-# Pins to make lockfile usable on multiple Python versions and platforms
-mypy = "*"
-atomicwrites = "*"
-typing-extensions = "*"
-importlib-metadata = "*"
-typed-ast = "*"
-# Test and docs dependencies
-pytest-cov = "*"
-pytest-mypy = "*"
-pytest-flake8 = "*"
-pytest-black = "*"
-flake8-isort = "*"
-isort = ">5.0"
-sphinx-rtd-theme = "*"
-sphinx-apischema = "*"
-autopep8 = "==1.5.7"
+# All other package requirements from setup.cfg
+ibek = {editable = true, path = ".", extras = ["dev"]}
 
 [packages]
-# Pins to make lockfile usable on multiple Python versions and platforms
-typing-extensions = "*"
 # All other package requirements from setup.cfg
-ibek = {editable = true,path = "."}
-jsonschema = "*"
+ibek = {editable = true, path = "."}
 
 [scripts]
 tests = "python -m pytest"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -44,7 +44,7 @@
                 "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15",
                 "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"
             ],
-            "markers": "python_version < '3.8'",
+            "markers": "python_version < '3.8' and python_version < '3.8'",
             "version": "==4.8.1"
         },
         "jinja2": {
@@ -177,7 +177,7 @@
                 "sha256:dc6a613d6c74eef5a14a214d433d06291526145431c3b964f5e16529b1842bed",
                 "sha256:de9c6b8a1ba52919ae919f3ae96abb72b994dd0350226e28f3686cb4f142165c"
             ],
-            "markers": "python_version < '3.10' and platform_python_implementation == 'CPython'",
+            "markers": "platform_python_implementation == 'CPython' and python_version < '3.10'",
             "version": "==0.2.6"
         },
         "typer": {
@@ -219,26 +219,12 @@
             ],
             "version": "==0.16.1"
         },
-        "atomicwrites": {
-            "hashes": [
-                "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197",
-                "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"
-            ],
-            "version": "==1.4.0"
-        },
         "attrs": {
             "hashes": [
                 "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
                 "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
             ],
             "version": "==21.2.0"
-        },
-        "autopep8": {
-            "hashes": [
-                "sha256:276ced7e9e3cb22e5d7c14748384a5cf5d9002257c0ed50c0e075b68011bb6d0",
-                "sha256:aa213493c30dcdac99537249ee65b24af0b2c29f2e83cd8b3f68760441ed0db9"
-            ],
-            "version": "==1.5.7"
         },
         "babel": {
             "hashes": [
@@ -382,7 +368,7 @@
                 "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15",
                 "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"
             ],
-            "markers": "python_version < '3.8'",
+            "markers": "python_version < '3.8' and python_version < '3.8'",
             "version": "==4.8.1"
         },
         "iniconfig": {
@@ -737,7 +723,7 @@
                 "sha256:dc6a613d6c74eef5a14a214d433d06291526145431c3b964f5e16529b1842bed",
                 "sha256:de9c6b8a1ba52919ae919f3ae96abb72b994dd0350226e28f3686cb4f142165c"
             ],
-            "markers": "python_version < '3.10' and platform_python_implementation == 'CPython'",
+            "markers": "platform_python_implementation == 'CPython' and python_version < '3.10'",
             "version": "==0.2.6"
         },
         "snowballstemmer": {
@@ -864,7 +850,7 @@
                 "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f",
                 "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"
             ],
-            "markers": "python_version < '3.8'",
+            "markers": "python_version < '3.8' and python_version < '3.8'",
             "version": "==1.4.3"
         },
         "typer": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "05ae82b18e148252f9dfb7b29001c6689896bf4a1e7dc347e8e6ee6c2f7ecf37"
+            "sha256": "52096b803fd3b078accff6c1fc1328f5aaac1498567e5975eb37143de4af2409"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -19,7 +19,6 @@
                 "sha256:8e540344bd1073d858f27ae65d5158729ff594488528fe8f84049b4e7a82af87",
                 "sha256:d89d1a439f0aad123596a2b4bc7130eba8e459a4f5748a4f3307e8fe97368796"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==0.16.1"
         },
         "attrs": {
@@ -27,7 +26,6 @@
                 "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
                 "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==21.2.0"
         },
         "click": {
@@ -35,20 +33,92 @@
                 "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3",
                 "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==8.0.3"
         },
         "ibek": {
             "editable": true,
             "path": "."
         },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15",
+                "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==4.8.1"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:827a0e32839ab1600d4eb1c4c33ec5a8edfbc5cb42dafa13b81f182f97784b45",
+                "sha256:8569982d3f0889eed11dd620c706d39b60c36d6d25843961f33f77fb6bc6b20c"
+            ],
+            "version": "==3.0.2"
+        },
         "jsonschema": {
             "hashes": [
                 "sha256:166870c8ab27bd712a8627e0598de4685bd8d199c4d7bd7cacc3d941ba0c6ca0",
                 "sha256:5c1a282ee6b74235057421fd0f766ac5f2972f77440927f6471c9e8493632fac"
             ],
-            "index": "pypi",
             "version": "==4.1.2"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298",
+                "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64",
+                "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b",
+                "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567",
+                "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff",
+                "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724",
+                "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74",
+                "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646",
+                "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35",
+                "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6",
+                "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6",
+                "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad",
+                "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26",
+                "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38",
+                "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac",
+                "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7",
+                "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6",
+                "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75",
+                "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f",
+                "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135",
+                "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8",
+                "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a",
+                "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a",
+                "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9",
+                "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864",
+                "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914",
+                "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18",
+                "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8",
+                "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2",
+                "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d",
+                "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b",
+                "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b",
+                "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f",
+                "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb",
+                "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833",
+                "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28",
+                "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415",
+                "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902",
+                "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d",
+                "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9",
+                "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d",
+                "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145",
+                "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066",
+                "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c",
+                "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1",
+                "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f",
+                "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53",
+                "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134",
+                "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85",
+                "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5",
+                "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94",
+                "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509",
+                "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51",
+                "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"
+            ],
+            "version": "==2.0.1"
         },
         "pyrsistent": {
             "hashes": [
@@ -74,7 +144,6 @@
                 "sha256:f3ef98d7b76da5eb19c37fda834d50262ff9167c65658d1d8f974d2e4d90676b",
                 "sha256:f4c8cabb46ff8e5d61f56a037974228e978f26bfefce4f61a4b1ac0ba7a2ab72"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==0.18.0"
         },
         "ruamel.yaml": {
@@ -82,7 +151,6 @@
                 "sha256:9751de4cbb57d4bfbf8fc394e125ed4a2f170fbff3dc3d78abf50be85924f8be",
                 "sha256:9af3ec5d7f8065582f3aa841305465025d0afd26c5fb54e15b964e11838fc74f"
             ],
-            "markers": "python_version >= '3'",
             "version": "==0.17.17"
         },
         "ruamel.yaml.clib": {
@@ -109,7 +177,7 @@
                 "sha256:dc6a613d6c74eef5a14a214d433d06291526145431c3b964f5e16529b1842bed",
                 "sha256:de9c6b8a1ba52919ae919f3ae96abb72b994dd0350226e28f3686cb4f142165c"
             ],
-            "markers": "platform_python_implementation == 'CPython' and python_version < '3.10'",
+            "markers": "python_version < '3.10' and platform_python_implementation == 'CPython'",
             "version": "==0.2.6"
         },
         "typer": {
@@ -117,7 +185,6 @@
                 "sha256:63c3aeab0549750ffe40da79a1b524f60e08a2cbc3126c520ebf2eeaf507f5dd",
                 "sha256:d81169725140423d072df464cad1ff25ee154ef381aaf5b8225352ea187ca338"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==0.4.0"
         },
         "typing-extensions": {
@@ -126,8 +193,15 @@
                 "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7",
                 "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"
             ],
-            "index": "pypi",
+            "markers": "python_version < '3.8'",
             "version": "==3.10.0.2"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832",
+                "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"
+            ],
+            "version": "==3.6.0"
         }
     },
     "develop": {
@@ -143,22 +217,13 @@
                 "sha256:8e540344bd1073d858f27ae65d5158729ff594488528fe8f84049b4e7a82af87",
                 "sha256:d89d1a439f0aad123596a2b4bc7130eba8e459a4f5748a4f3307e8fe97368796"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==0.16.1"
-        },
-        "appdirs": {
-            "hashes": [
-                "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41",
-                "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"
-            ],
-            "version": "==1.4.4"
         },
         "atomicwrites": {
             "hashes": [
                 "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197",
                 "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"
             ],
-            "index": "pypi",
             "version": "==1.4.0"
         },
         "attrs": {
@@ -166,7 +231,6 @@
                 "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
                 "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==21.2.0"
         },
         "autopep8": {
@@ -174,7 +238,6 @@
                 "sha256:276ced7e9e3cb22e5d7c14748384a5cf5d9002257c0ed50c0e075b68011bb6d0",
                 "sha256:aa213493c30dcdac99537249ee65b24af0b2c29f2e83cd8b3f68760441ed0db9"
             ],
-            "index": "pypi",
             "version": "==1.5.7"
         },
         "babel": {
@@ -182,16 +245,14 @@
                 "sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9",
                 "sha256:bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.9.1"
         },
         "black": {
             "hashes": [
-                "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b",
-                "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"
+                "sha256:380f1b5da05e5a1429225676655dddb96f5ae8c75bdf91e53d798871b902a115",
+                "sha256:7de4cfc7eb6b710de325712d40125689101d21d25283eed7e9998722cf10eb91"
             ],
-            "index": "pypi",
-            "version": "==19.10b0"
+            "version": "==21.9b0"
         },
         "certifi": {
             "hashes": [
@@ -213,7 +274,6 @@
                 "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3",
                 "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==8.0.3"
         },
         "coverage": {
@@ -268,7 +328,6 @@
                 "sha256:fb2fa2f6506c03c48ca42e3fe5a692d7470d290c047ee6de7c0f3e5fa7639ac9",
                 "sha256:ffa8fee2b1b9e60b531c4c27cf528d6b5d5da46b1730db1f4d6eee56ff282e07"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==6.1.1"
         },
         "docutils": {
@@ -276,7 +335,6 @@
                 "sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125",
                 "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.17.1"
         },
         "filelock": {
@@ -284,7 +342,6 @@
                 "sha256:7afc856f74fa7006a289fd10fa840e1eebd8bbff6bffb69c26c54a0512ea8cf8",
                 "sha256:bb2a1c717df74c48a2d00ed625e5a66f8572a3a30baacb7657add1d7bac4097b"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==3.3.2"
         },
         "flake8": {
@@ -292,7 +349,6 @@
                 "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b",
                 "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"
             ],
-            "index": "pypi",
             "version": "==3.9.2"
         },
         "flake8-isort": {
@@ -300,8 +356,11 @@
                 "sha256:c4e8b6dcb7be9b71a02e6e5d4196cefcef0f3447be51e82730fb336fff164949",
                 "sha256:d814304ab70e6e58859bc5c3e221e2e6e71c958e7005239202fee19c24f82717"
             ],
-            "index": "pypi",
             "version": "==4.1.1"
+        },
+        "ibek": {
+            "editable": true,
+            "path": "."
         },
         "idna": {
             "hashes": [
@@ -316,7 +375,6 @@
                 "sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1",
                 "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.2.0"
         },
         "importlib-metadata": {
@@ -324,7 +382,7 @@
                 "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15",
                 "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"
             ],
-            "index": "pypi",
+            "markers": "python_version < '3.8'",
             "version": "==4.8.1"
         },
         "iniconfig": {
@@ -339,7 +397,6 @@
                 "sha256:1a18ccace2ed8910bd9458b74a3ecbafd7b2f581301b0ab65cfdd4338272d76f",
                 "sha256:e52ff6d38012b131628cf0f26c51e7bd3a7c81592eefe3ac71411e692f1b9345"
             ],
-            "index": "pypi",
             "version": "==5.10.0"
         },
         "jinja2": {
@@ -347,15 +404,20 @@
                 "sha256:827a0e32839ab1600d4eb1c4c33ec5a8edfbc5cb42dafa13b81f182f97784b45",
                 "sha256:8569982d3f0889eed11dd620c706d39b60c36d6d25843961f33f77fb6bc6b20c"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==3.0.2"
+        },
+        "jsonschema": {
+            "hashes": [
+                "sha256:166870c8ab27bd712a8627e0598de4685bd8d199c4d7bd7cacc3d941ba0c6ca0",
+                "sha256:5c1a282ee6b74235057421fd0f766ac5f2972f77440927f6471c9e8493632fac"
+            ],
+            "version": "==4.1.2"
         },
         "markupsafe": {
             "hashes": [
                 "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298",
                 "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64",
                 "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b",
-                "sha256:04635854b943835a6ea959e948d19dcd311762c5c0c6e1f0e16ee57022669194",
                 "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567",
                 "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff",
                 "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724",
@@ -363,7 +425,6 @@
                 "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646",
                 "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35",
                 "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6",
-                "sha256:20dca64a3ef2d6e4d5d615a3fd418ad3bde77a47ec8a23d984a12b5b4c74491a",
                 "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6",
                 "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad",
                 "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26",
@@ -371,36 +432,27 @@
                 "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac",
                 "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7",
                 "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6",
-                "sha256:4296f2b1ce8c86a6aea78613c34bb1a672ea0e3de9c6ba08a960efe0b0a09047",
                 "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75",
                 "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f",
-                "sha256:4dc8f9fb58f7364b63fd9f85013b780ef83c11857ae79f2feda41e270468dd9b",
                 "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135",
                 "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8",
                 "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a",
                 "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a",
-                "sha256:5b6d930f030f8ed98e3e6c98ffa0652bdb82601e7a016ec2ab5d7ff23baa78d1",
                 "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9",
                 "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864",
                 "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914",
-                "sha256:6300b8454aa6930a24b9618fbb54b5a68135092bc666f7b06901f897fa5c2fee",
-                "sha256:63f3268ba69ace99cab4e3e3b5840b03340efed0948ab8f78d2fd87ee5442a4f",
                 "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18",
                 "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8",
                 "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2",
                 "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d",
                 "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b",
                 "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b",
-                "sha256:89c687013cb1cd489a0f0ac24febe8c7a666e6e221b783e53ac50ebf68e45d86",
-                "sha256:8d206346619592c6200148b01a2142798c989edcb9c896f9ac9722a99d4e77e6",
                 "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f",
                 "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb",
                 "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833",
                 "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28",
-                "sha256:9f02365d4e99430a12647f09b6cc8bab61a6564363f313126f775eb4f6ef798e",
                 "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415",
                 "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902",
-                "sha256:aca6377c0cb8a8253e493c6b451565ac77e98c2951c45f913e0b52facdcff83f",
                 "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d",
                 "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9",
                 "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d",
@@ -408,21 +460,16 @@
                 "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066",
                 "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c",
                 "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1",
-                "sha256:cdfba22ea2f0029c9261a4bd07e830a8da012291fbe44dc794e488b6c9bb353a",
-                "sha256:d6c7ebd4e944c85e2c3421e612a7057a2f48d478d79e61800d81468a8d842207",
                 "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f",
                 "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53",
-                "sha256:deb993cacb280823246a026e3b2d81c493c53de6acfd5e6bfe31ab3402bb37dd",
                 "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134",
                 "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85",
-                "sha256:f0567c4dc99f264f49fe27da5f735f414c4e7e7dd850cfd8e69f0862d7c74ea9",
                 "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5",
                 "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94",
                 "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509",
                 "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51",
                 "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==2.0.1"
         },
         "mccabe": {
@@ -458,7 +505,7 @@
                 "sha256:ecd2c3fe726758037234c93df7e98deb257fd15c24c9180dacf1ef829da5f921",
                 "sha256:ef565033fa5a958e62796867b1df10c40263ea9ded87164d67572834e57a174d"
             ],
-            "index": "pypi",
+            "markers": "python_version < '3.8'",
             "version": "==0.910"
         },
         "mypy-extensions": {
@@ -473,7 +520,6 @@
                 "sha256:096d689d78ca690e4cd8a89568ba06d07ca097e3306a4381635073ca91479966",
                 "sha256:14317396d1e8cdb122989b916fa2c7e9ca8e2be9e8060a6eff75b6b7b4d8a7e0"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==21.2"
         },
         "pathspec": {
@@ -483,12 +529,18 @@
             ],
             "version": "==0.9.0"
         },
+        "platformdirs": {
+            "hashes": [
+                "sha256:367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2",
+                "sha256:8868bbe3c3c80d42f20156f22e7131d2fb321f5bc86a2a345375c6481a67021d"
+            ],
+            "version": "==2.4.0"
+        },
         "pluggy": {
             "hashes": [
                 "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
                 "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==1.0.0"
         },
         "py": {
@@ -496,7 +548,6 @@
                 "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
                 "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.10.0"
         },
         "pycodestyle": {
@@ -504,7 +555,6 @@
                 "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068",
                 "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.7.0"
         },
         "pyflakes": {
@@ -512,7 +562,6 @@
                 "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3",
                 "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.3.1"
         },
         "pygments": {
@@ -520,7 +569,6 @@
                 "sha256:b8e67fe6af78f492b3c4b3e2970c0624cbf08beb1e493b2c99b9fa1b67a20380",
                 "sha256:f398865f7eb6874156579fdf36bc840a03cab64d1cde9e93d68f46a425ec52c6"
             ],
-            "markers": "python_version >= '3.5'",
             "version": "==2.10.0"
         },
         "pyparsing": {
@@ -528,22 +576,45 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.4.7"
+        },
+        "pyrsistent": {
+            "hashes": [
+                "sha256:097b96f129dd36a8c9e33594e7ebb151b1515eb52cceb08474c10a5479e799f2",
+                "sha256:2aaf19dc8ce517a8653746d98e962ef480ff34b6bc563fc067be6401ffb457c7",
+                "sha256:404e1f1d254d314d55adb8d87f4f465c8693d6f902f67eb6ef5b4526dc58e6ea",
+                "sha256:48578680353f41dca1ca3dc48629fb77dfc745128b56fc01096b2530c13fd426",
+                "sha256:4916c10896721e472ee12c95cdc2891ce5890898d2f9907b1b4ae0f53588b710",
+                "sha256:527be2bfa8dc80f6f8ddd65242ba476a6c4fb4e3aedbf281dfbac1b1ed4165b1",
+                "sha256:58a70d93fb79dc585b21f9d72487b929a6fe58da0754fa4cb9f279bb92369396",
+                "sha256:5e4395bbf841693eaebaa5bb5c8f5cdbb1d139e07c975c682ec4e4f8126e03d2",
+                "sha256:6b5eed00e597b5b5773b4ca30bd48a5774ef1e96f2a45d105db5b4ebb4bca680",
+                "sha256:73ff61b1411e3fb0ba144b8f08d6749749775fe89688093e1efef9839d2dcc35",
+                "sha256:772e94c2c6864f2cd2ffbe58bb3bdefbe2a32afa0acb1a77e472aac831f83427",
+                "sha256:773c781216f8c2900b42a7b638d5b517bb134ae1acbebe4d1e8f1f41ea60eb4b",
+                "sha256:a0c772d791c38bbc77be659af29bb14c38ced151433592e326361610250c605b",
+                "sha256:b29b869cf58412ca5738d23691e96d8aff535e17390128a1a52717c9a109da4f",
+                "sha256:c1a9ff320fa699337e05edcaae79ef8c2880b52720bc031b219e5b5008ebbdef",
+                "sha256:cd3caef37a415fd0dae6148a1b6957a8c5f275a62cca02e18474608cb263640c",
+                "sha256:d5ec194c9c573aafaceebf05fc400656722793dac57f254cd4741f3c27ae57b4",
+                "sha256:da6e5e818d18459fa46fac0a4a4e543507fe1110e808101277c5a2b5bab0cd2d",
+                "sha256:e79d94ca58fcafef6395f6352383fa1a76922268fa02caa2272fff501c2fdc78",
+                "sha256:f3ef98d7b76da5eb19c37fda834d50262ff9167c65658d1d8f974d2e4d90676b",
+                "sha256:f4c8cabb46ff8e5d61f56a037974228e978f26bfefce4f61a4b1ac0ba7a2ab72"
+            ],
+            "version": "==0.18.0"
         },
         "pytest": {
             "hashes": [
                 "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89",
                 "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==6.2.5"
         },
         "pytest-black": {
             "hashes": [
                 "sha256:1d339b004f764d6cd0f06e690f6dd748df3d62e6fe1a692d6a5500ac2c5b75a5"
             ],
-            "index": "pypi",
             "version": "==0.3.12"
         },
         "pytest-cov": {
@@ -551,7 +622,6 @@
                 "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6",
                 "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"
             ],
-            "index": "pypi",
             "version": "==3.0.0"
         },
         "pytest-flake8": {
@@ -559,7 +629,6 @@
                 "sha256:c28cf23e7d359753c896745fd4ba859495d02e16c84bac36caa8b1eec58f5bc1",
                 "sha256:f0259761a903563f33d6f099914afef339c085085e643bee8343eb323b32dd6b"
             ],
-            "index": "pypi",
             "version": "==1.0.7"
         },
         "pytest-mypy": {
@@ -567,7 +636,6 @@
                 "sha256:1fa55723a4bf1d054fcba1c3bd694215a2a65cc95ab10164f5808afd893f3b11",
                 "sha256:6e68e8eb7ceeb7d1c83a1590912f784879f037b51adfb9c17b95c6b2fc57466b"
             ],
-            "index": "pypi",
             "version": "==0.8.1"
         },
         "pytz": {
@@ -636,8 +704,41 @@
                 "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
                 "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==2.26.0"
+        },
+        "ruamel.yaml": {
+            "hashes": [
+                "sha256:9751de4cbb57d4bfbf8fc394e125ed4a2f170fbff3dc3d78abf50be85924f8be",
+                "sha256:9af3ec5d7f8065582f3aa841305465025d0afd26c5fb54e15b964e11838fc74f"
+            ],
+            "version": "==0.17.17"
+        },
+        "ruamel.yaml.clib": {
+            "hashes": [
+                "sha256:0847201b767447fc33b9c235780d3aa90357d20dd6108b92be544427bea197dd",
+                "sha256:1866cf2c284a03b9524a5cc00daca56d80057c5ce3cdc86a52020f4c720856f0",
+                "sha256:31ea73e564a7b5fbbe8188ab8b334393e06d997914a4e184975348f204790277",
+                "sha256:3fb9575a5acd13031c57a62cc7823e5d2ff8bc3835ba4d94b921b4e6ee664104",
+                "sha256:4ff604ce439abb20794f05613c374759ce10e3595d1867764dd1ae675b85acbd",
+                "sha256:72a2b8b2ff0a627496aad76f37a652bcef400fd861721744201ef1b45199ab78",
+                "sha256:78988ed190206672da0f5d50c61afef8f67daa718d614377dcd5e3ed85ab4a99",
+                "sha256:7b2927e92feb51d830f531de4ccb11b320255ee95e791022555971c466af4527",
+                "sha256:7f7ecb53ae6848f959db6ae93bdff1740e651809780822270eab111500842a84",
+                "sha256:825d5fccef6da42f3c8eccd4281af399f21c02b32d98e113dbc631ea6a6ecbc7",
+                "sha256:846fc8336443106fe23f9b6d6b8c14a53d38cef9a375149d61f99d78782ea468",
+                "sha256:89221ec6d6026f8ae859c09b9718799fea22c0e8da8b766b0b2c9a9ba2db326b",
+                "sha256:9efef4aab5353387b07f6b22ace0867032b900d8e91674b5d8ea9150db5cae94",
+                "sha256:a32f8d81ea0c6173ab1b3da956869114cae53ba1e9f72374032e33ba3118c233",
+                "sha256:a49e0161897901d1ac9c4a79984b8410f450565bbad64dbfcbf76152743a0cdb",
+                "sha256:ada3f400d9923a190ea8b59c8f60680c4ef8a4b0dfae134d2f2ff68429adfab5",
+                "sha256:bf75d28fa071645c529b5474a550a44686821decebdd00e21127ef1fd566eabe",
+                "sha256:cfdb9389d888c5b74af297e51ce357b800dd844898af9d4a547ffc143fa56751",
+                "sha256:d67f273097c368265a7b81e152e07fb90ed395df6e552b9fa858c6d2c9f42502",
+                "sha256:dc6a613d6c74eef5a14a214d433d06291526145431c3b964f5e16529b1842bed",
+                "sha256:de9c6b8a1ba52919ae919f3ae96abb72b994dd0350226e28f3686cb4f142165c"
+            ],
+            "markers": "python_version < '3.10' and platform_python_implementation == 'CPython'",
+            "version": "==0.2.6"
         },
         "snowballstemmer": {
             "hashes": [
@@ -651,15 +752,13 @@
                 "sha256:94078db9184491e15bce0a56d9186e0aec95f16ac20b12d00e06d4e36f1058a6",
                 "sha256:98a535c62a4fcfcc362528592f69b26f7caec587d32cd55688db580be0287ae0"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==4.2.0"
         },
         "sphinx-apischema": {
             "hashes": [
-                "sha256:9e5d6c3f407fdd1c6b60b3769a5a5265265e0a542dd021f0f7e526cfa3df45e2",
-                "sha256:be8b057a38e585d00bec70c9a5ab6d133bb3d933e61c5aebadd15fc0c2129d7b"
+                "sha256:be8b057a38e585d00bec70c9a5ab6d133bb3d933e61c5aebadd15fc0c2129d7b",
+                "sha256:d08bc8a6fde414e0569bea2bfe107af155ded1791520d3140edb2e238c31b1c2"
             ],
-            "index": "pypi",
             "version": "==0.1"
         },
         "sphinx-rtd-theme": {
@@ -667,7 +766,6 @@
                 "sha256:4d35a56f4508cfee4c4fb604373ede6feae2a306731d533f409ef5c3496fdbd8",
                 "sha256:eec6d497e4c2195fa0e8b2016b337532b8a699a68bcb22a512870e16925c6a5c"
             ],
-            "index": "pypi",
             "version": "==1.0.0"
         },
         "sphinxcontrib-applehelp": {
@@ -675,7 +773,6 @@
                 "sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a",
                 "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"
             ],
-            "markers": "python_version >= '3.5'",
             "version": "==1.0.2"
         },
         "sphinxcontrib-devhelp": {
@@ -683,7 +780,6 @@
                 "sha256:8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e",
                 "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"
             ],
-            "markers": "python_version >= '3.5'",
             "version": "==1.0.2"
         },
         "sphinxcontrib-htmlhelp": {
@@ -691,7 +787,6 @@
                 "sha256:d412243dfb797ae3ec2b59eca0e52dac12e75a241bf0e4eb861e450d06c6ed07",
                 "sha256:f5f8bb2d0d629f398bf47d0d69c07bc13b65f75a81ad9e2f71a63d4b7a2f6db2"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==2.0.0"
         },
         "sphinxcontrib-jsmath": {
@@ -699,7 +794,6 @@
                 "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178",
                 "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"
             ],
-            "markers": "python_version >= '3.5'",
             "version": "==1.0.1"
         },
         "sphinxcontrib-qthelp": {
@@ -707,7 +801,6 @@
                 "sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72",
                 "sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6"
             ],
-            "markers": "python_version >= '3.5'",
             "version": "==1.0.3"
         },
         "sphinxcontrib-serializinghtml": {
@@ -715,7 +808,6 @@
                 "sha256:352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd",
                 "sha256:aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952"
             ],
-            "markers": "python_version >= '3.5'",
             "version": "==1.1.5"
         },
         "testfixtures": {
@@ -730,7 +822,6 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.10.2"
         },
         "tomli": {
@@ -773,8 +864,15 @@
                 "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f",
                 "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"
             ],
-            "index": "pypi",
+            "markers": "python_version < '3.8'",
             "version": "==1.4.3"
+        },
+        "typer": {
+            "hashes": [
+                "sha256:63c3aeab0549750ffe40da79a1b524f60e08a2cbc3126c520ebf2eeaf507f5dd",
+                "sha256:d81169725140423d072df464cad1ff25ee154ef381aaf5b8225352ea187ca338"
+            ],
+            "version": "==0.4.0"
         },
         "typing-extensions": {
             "hashes": [
@@ -782,7 +880,7 @@
                 "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7",
                 "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"
             ],
-            "index": "pypi",
+            "markers": "python_version < '3.8'",
             "version": "==3.10.0.2"
         },
         "urllib3": {
@@ -790,7 +888,6 @@
                 "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
                 "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.26.7"
         },
         "zipp": {
@@ -798,7 +895,6 @@
                 "sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832",
                 "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==3.6.0"
         }
     }

--- a/ibek/globals.py
+++ b/ibek/globals.py
@@ -10,5 +10,5 @@ T = TypeVar("T")
 
 
 def desc(description: str):
-    """ a description Annotation to add to our Entity derived Types """
+    """a description Annotation to add to our Entity derived Types"""
     return schema(description=description)

--- a/ibek/helm.py
+++ b/ibek/helm.py
@@ -127,7 +127,8 @@ def create_helm(ioc_dict: Dict, entity_yaml: str, path: Path):
         description=ioc_dict["description"],
     )
     render_file(
-        helm_folder / "values.yaml.jinja", base_image=ioc_dict["generic_ioc_image"],
+        helm_folder / "values.yaml.jinja",
+        base_image=ioc_dict["generic_ioc_image"],
     )
 
     boot_script_path = helm_folder / "config" / "ioc.boot.yaml"

--- a/ibek/ioc.py
+++ b/ibek/ioc.py
@@ -35,7 +35,6 @@ from .globals import T, desc
 from .support import Definition, ObjectArg, StrArg, Support
 
 
-@dataclass
 class Entity:
     """
     A baseclass for all generated Entity classes. Provides the
@@ -45,6 +44,7 @@ class Entity:
     # a link back to the Definition Object that generated this Definition
     __definition__: ClassVar[Definition]
     __instances__: ClassVar[Dict[str, Entity]]
+    entity_disabled: bool
 
     def __post_init__(self):
         # If there is an argument which is an id then allow deserialization by that
@@ -100,6 +100,10 @@ def make_entity_class(definition: Definition, support: Support) -> Type[Entity]:
     # a unique key for each of the entity types we may instantiate
     full_name = f"{support.module}.{definition.name}"
     fields.append(("type", Literal[full_name], field(default=cast(Any, full_name))))
+
+    # add a field so we can control rendering of the entity without having to delete
+    # it
+    fields.append(("entity_disabled", bool, field(default=cast(Any, False))))
 
     namespace = dict(
         __definition__=definition, __instances__={}, __module__="ibek.modules"

--- a/ibek/ioc.py
+++ b/ibek/ioc.py
@@ -6,18 +6,7 @@ from __future__ import annotations
 
 import types
 from dataclasses import Field, dataclass, field, make_dataclass
-from typing import (
-    Any,
-    ClassVar,
-    Dict,
-    List,
-    Mapping,
-    Sequence,
-    Tuple,
-    Type,
-    Union,
-    cast,
-)
+from typing import Any, Dict, List, Mapping, Sequence, Tuple, Type, Union, cast
 
 from apischema import Undefined, cache, deserialize, deserializer
 from apischema.conversions import (
@@ -42,8 +31,8 @@ class Entity:
     """
 
     # a link back to the Definition Object that generated this Definition
-    __definition__: ClassVar[Definition]
-    __instances__: ClassVar[Dict[str, Entity]]
+    __definition__: Definition
+    __instances__: Dict[str, Entity]
     entity_disabled: bool
 
     def __post_init__(self):

--- a/ibek/render.py
+++ b/ibek/render.py
@@ -97,9 +97,10 @@ def render_elements(ioc: IOC, element: str) -> str:
     method = getattr(sys.modules[__name__], element)
     elements = ""
     for instance in ioc.entities:
-        element = method(instance)
-        if element:
-            elements += element + "\n"
+        if not instance.entity_disabled:
+            element = method(instance)
+            if element:
+                elements += element + "\n"
     return elements
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,12 +34,6 @@ dev =
     black==21.9b0
     # Flake version 4.0 and 4.0.1 do not like pytest: https://github.com/tholo/pytest-flake8/issues/81
     flake8==3.9.2
-    # Pins to make lockfile usable on multiple Python versions and platforms
-    mypy
-    atomicwrites
-    typing-extensions
-    importlib-metadata
-    typed-ast
     # Test and docs dependencies
     pytest-cov
     pytest-mypy
@@ -49,7 +43,6 @@ dev =
     isort>=5.0
     sphinx-rtd-theme
     sphinx-apischema
-    autopep8==1.5.7
 
 [options.entry_points]
 # Include a command line script

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,10 +22,34 @@ install_requires =
      typer
      ruamel.yaml
      jsonschema
+     jinja2
 
 [options.packages.find]
 # Don't include our tests directory in the distribution
 exclude = tests
+
+[options.extras_require]
+dev =
+    # Pinning black stops us having to allow pre-releases globally
+    black==21.9b0
+    # Flake version 4.0 and 4.0.1 do not like pytest: https://github.com/tholo/pytest-flake8/issues/81
+    flake8==3.9.2
+    # Pins to make lockfile usable on multiple Python versions and platforms
+    mypy
+    atomicwrites
+    typing-extensions
+    importlib-metadata
+    typed-ast
+    # Test and docs dependencies
+    pytest-cov
+    pytest-mypy
+    pytest-flake8
+    pytest-black
+    flake8-isort
+    isort>=5.0
+    sphinx-rtd-theme
+    sphinx-apischema
+    autopep8==1.5.7
 
 [options.entry_points]
 # Include a command line script

--- a/tests/samples/schemas/asyn.schema.json
+++ b/tests/samples/schemas/asyn.schema.json
@@ -69,6 +69,10 @@
                 "type": "string",
                 "const": "asyn.AsynSerial",
                 "default": "asyn.AsynSerial"
+              },
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
               }
             },
             "required": [
@@ -116,6 +120,10 @@
                 "type": "string",
                 "const": "asyn.AsynIP",
                 "default": "asyn.AsynIP"
+              },
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
               }
             },
             "required": [

--- a/tests/samples/schemas/asyn.schema.json
+++ b/tests/samples/schemas/asyn.schema.json
@@ -16,6 +16,10 @@
           {
             "type": "object",
             "properties": {
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
+              },
               "port": {
                 "type": "string",
                 "description": "The port name for this asyn object"
@@ -69,10 +73,6 @@
                 "type": "string",
                 "const": "asyn.AsynSerial",
                 "default": "asyn.AsynSerial"
-              },
-              "entity_disabled": {
-                "type": "boolean",
-                "default": false
               }
             },
             "required": [
@@ -83,6 +83,10 @@
           {
             "type": "object",
             "properties": {
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
+              },
               "port": {
                 "type": "string",
                 "description": "Serial port tty name / IP address optionally followed by protocol"
@@ -120,10 +124,6 @@
                 "type": "string",
                 "const": "asyn.AsynIP",
                 "default": "asyn.AsynIP"
-              },
-              "entity_disabled": {
-                "type": "boolean",
-                "default": false
               }
             },
             "required": [

--- a/tests/samples/schemas/bl45p-mo-ioc-04.schema.json
+++ b/tests/samples/schemas/bl45p-mo-ioc-04.schema.json
@@ -25,6 +25,10 @@
                 "type": "string",
                 "const": "epics.EPICS_CA_MAX_ARRAY_BYTES",
                 "default": "epics.EPICS_CA_MAX_ARRAY_BYTES"
+              },
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
               }
             },
             "additionalProperties": false
@@ -41,6 +45,10 @@
                 "type": "string",
                 "const": "epics.EPICS_TS_MIN_WEST",
                 "default": "epics.EPICS_TS_MIN_WEST"
+              },
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
               }
             },
             "additionalProperties": false
@@ -60,6 +68,10 @@
                 "type": "string",
                 "const": "epics.dbpf",
                 "default": "epics.dbpf"
+              },
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
               }
             },
             "required": [
@@ -83,6 +95,10 @@
                 "type": "string",
                 "const": "epics.epicsEnvSet",
                 "default": "epics.epicsEnvSet"
+              },
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
               }
             },
             "required": [
@@ -122,6 +138,10 @@
                 "type": "string",
                 "const": "pmac.Geobrick",
                 "default": "pmac.Geobrick"
+              },
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
               }
             },
             "required": [
@@ -149,6 +169,10 @@
                 "type": "string",
                 "const": "pmac.PmacAsynIPPort",
                 "default": "pmac.PmacAsynIPPort"
+              },
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
               }
             },
             "required": [
@@ -425,6 +449,10 @@
                 "type": "string",
                 "const": "pmac.DlsPmacAsynMotor",
                 "default": "pmac.DlsPmacAsynMotor"
+              },
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
               }
             },
             "required": [

--- a/tests/samples/schemas/bl45p-mo-ioc-04.schema.json
+++ b/tests/samples/schemas/bl45p-mo-ioc-04.schema.json
@@ -16,6 +16,10 @@
           {
             "type": "object",
             "properties": {
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
+              },
               "max_bytes": {
                 "type": "integer",
                 "description": "Max size in bytes for sending arrays over channel access",
@@ -25,10 +29,6 @@
                 "type": "string",
                 "const": "epics.EPICS_CA_MAX_ARRAY_BYTES",
                 "default": "epics.EPICS_CA_MAX_ARRAY_BYTES"
-              },
-              "entity_disabled": {
-                "type": "boolean",
-                "default": false
               }
             },
             "additionalProperties": false
@@ -36,6 +36,10 @@
           {
             "type": "object",
             "properties": {
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
+              },
               "minutes_west": {
                 "type": "integer",
                 "description": "Set relative time zone minutes West relative to GMT (+/-720)",
@@ -45,10 +49,6 @@
                 "type": "string",
                 "const": "epics.EPICS_TS_MIN_WEST",
                 "default": "epics.EPICS_TS_MIN_WEST"
-              },
-              "entity_disabled": {
-                "type": "boolean",
-                "default": false
               }
             },
             "additionalProperties": false
@@ -56,6 +56,10 @@
           {
             "type": "object",
             "properties": {
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
+              },
               "pv": {
                 "type": "string",
                 "description": "Name of PV"
@@ -68,10 +72,6 @@
                 "type": "string",
                 "const": "epics.dbpf",
                 "default": "epics.dbpf"
-              },
-              "entity_disabled": {
-                "type": "boolean",
-                "default": false
               }
             },
             "required": [
@@ -83,6 +83,10 @@
           {
             "type": "object",
             "properties": {
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
+              },
               "name": {
                 "type": "string",
                 "description": "Name of environment variable"
@@ -95,10 +99,6 @@
                 "type": "string",
                 "const": "epics.epicsEnvSet",
                 "default": "epics.epicsEnvSet"
-              },
-              "entity_disabled": {
-                "type": "boolean",
-                "default": false
               }
             },
             "required": [
@@ -110,6 +110,10 @@
           {
             "type": "object",
             "properties": {
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
+              },
               "name": {
                 "type": "string",
                 "description": "Name to use for the geobrick's asyn port"
@@ -138,10 +142,6 @@
                 "type": "string",
                 "const": "pmac.Geobrick",
                 "default": "pmac.Geobrick"
-              },
-              "entity_disabled": {
-                "type": "boolean",
-                "default": false
               }
             },
             "required": [
@@ -157,6 +157,10 @@
           {
             "type": "object",
             "properties": {
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
+              },
               "name": {
                 "type": "string",
                 "description": "Asyn port name"
@@ -169,10 +173,6 @@
                 "type": "string",
                 "const": "pmac.PmacAsynIPPort",
                 "default": "pmac.PmacAsynIPPort"
-              },
-              "entity_disabled": {
-                "type": "boolean",
-                "default": false
               }
             },
             "required": [
@@ -184,6 +184,10 @@
           {
             "type": "object",
             "properties": {
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
+              },
               "PMAC": {
                 "type": "string",
                 "description": "PMAC to attach to"
@@ -449,10 +453,6 @@
                 "type": "string",
                 "const": "pmac.DlsPmacAsynMotor",
                 "default": "pmac.DlsPmacAsynMotor"
-              },
-              "entity_disabled": {
-                "type": "boolean",
-                "default": false
               }
             },
             "required": [

--- a/tests/samples/schemas/container.schema.json
+++ b/tests/samples/schemas/container.schema.json
@@ -16,6 +16,10 @@
           {
             "type": "object",
             "properties": {
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
+              },
               "port": {
                 "type": "string",
                 "description": "The port name for this asyn object"
@@ -69,10 +73,6 @@
                 "type": "string",
                 "const": "asyn.AsynSerial",
                 "default": "asyn.AsynSerial"
-              },
-              "entity_disabled": {
-                "type": "boolean",
-                "default": false
               }
             },
             "required": [
@@ -83,6 +83,10 @@
           {
             "type": "object",
             "properties": {
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
+              },
               "port": {
                 "type": "string",
                 "description": "Serial port tty name / IP address optionally followed by protocol"
@@ -120,10 +124,6 @@
                 "type": "string",
                 "const": "asyn.AsynIP",
                 "default": "asyn.AsynIP"
-              },
-              "entity_disabled": {
-                "type": "boolean",
-                "default": false
               }
             },
             "required": [
@@ -135,6 +135,10 @@
           {
             "type": "object",
             "properties": {
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
+              },
               "name": {
                 "type": "string",
                 "description": "Name to use for the geobrick's asyn port"
@@ -163,10 +167,6 @@
                 "type": "string",
                 "const": "pmac.Geobrick",
                 "default": "pmac.Geobrick"
-              },
-              "entity_disabled": {
-                "type": "boolean",
-                "default": false
               }
             },
             "required": [
@@ -182,6 +182,10 @@
           {
             "type": "object",
             "properties": {
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
+              },
               "name": {
                 "type": "string",
                 "description": "Asyn port name"
@@ -194,10 +198,6 @@
                 "type": "string",
                 "const": "pmac.PmacAsynIPPort",
                 "default": "pmac.PmacAsynIPPort"
-              },
-              "entity_disabled": {
-                "type": "boolean",
-                "default": false
               }
             },
             "required": [
@@ -209,6 +209,10 @@
           {
             "type": "object",
             "properties": {
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
+              },
               "PMAC": {
                 "type": "string",
                 "description": "PMAC to attach to"
@@ -474,10 +478,6 @@
                 "type": "string",
                 "const": "pmac.DlsPmacAsynMotor",
                 "default": "pmac.DlsPmacAsynMotor"
-              },
-              "entity_disabled": {
-                "type": "boolean",
-                "default": false
               }
             },
             "required": [

--- a/tests/samples/schemas/container.schema.json
+++ b/tests/samples/schemas/container.schema.json
@@ -69,6 +69,10 @@
                 "type": "string",
                 "const": "asyn.AsynSerial",
                 "default": "asyn.AsynSerial"
+              },
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
               }
             },
             "required": [
@@ -116,6 +120,10 @@
                 "type": "string",
                 "const": "asyn.AsynIP",
                 "default": "asyn.AsynIP"
+              },
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
               }
             },
             "required": [
@@ -155,6 +163,10 @@
                 "type": "string",
                 "const": "pmac.Geobrick",
                 "default": "pmac.Geobrick"
+              },
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
               }
             },
             "required": [
@@ -182,6 +194,10 @@
                 "type": "string",
                 "const": "pmac.PmacAsynIPPort",
                 "default": "pmac.PmacAsynIPPort"
+              },
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
               }
             },
             "required": [
@@ -458,6 +474,10 @@
                 "type": "string",
                 "const": "pmac.DlsPmacAsynMotor",
                 "default": "pmac.DlsPmacAsynMotor"
+              },
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
               }
             },
             "required": [

--- a/tests/samples/schemas/epics.schema.json
+++ b/tests/samples/schemas/epics.schema.json
@@ -16,6 +16,10 @@
           {
             "type": "object",
             "properties": {
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
+              },
               "max_bytes": {
                 "type": "integer",
                 "description": "Max size in bytes for sending arrays over channel access",
@@ -25,10 +29,6 @@
                 "type": "string",
                 "const": "epics.EPICS_CA_MAX_ARRAY_BYTES",
                 "default": "epics.EPICS_CA_MAX_ARRAY_BYTES"
-              },
-              "entity_disabled": {
-                "type": "boolean",
-                "default": false
               }
             },
             "additionalProperties": false
@@ -36,6 +36,10 @@
           {
             "type": "object",
             "properties": {
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
+              },
               "minutes_west": {
                 "type": "integer",
                 "description": "Set relative time zone minutes West relative to GMT (+/-720)",
@@ -45,10 +49,6 @@
                 "type": "string",
                 "const": "epics.EPICS_TS_MIN_WEST",
                 "default": "epics.EPICS_TS_MIN_WEST"
-              },
-              "entity_disabled": {
-                "type": "boolean",
-                "default": false
               }
             },
             "additionalProperties": false
@@ -56,6 +56,10 @@
           {
             "type": "object",
             "properties": {
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
+              },
               "pv": {
                 "type": "string",
                 "description": "Name of PV"
@@ -68,10 +72,6 @@
                 "type": "string",
                 "const": "epics.dbpf",
                 "default": "epics.dbpf"
-              },
-              "entity_disabled": {
-                "type": "boolean",
-                "default": false
               }
             },
             "required": [
@@ -83,6 +83,10 @@
           {
             "type": "object",
             "properties": {
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
+              },
               "name": {
                 "type": "string",
                 "description": "Name of environment variable"
@@ -95,10 +99,6 @@
                 "type": "string",
                 "const": "epics.epicsEnvSet",
                 "default": "epics.epicsEnvSet"
-              },
-              "entity_disabled": {
-                "type": "boolean",
-                "default": false
               }
             },
             "required": [

--- a/tests/samples/schemas/epics.schema.json
+++ b/tests/samples/schemas/epics.schema.json
@@ -25,6 +25,10 @@
                 "type": "string",
                 "const": "epics.EPICS_CA_MAX_ARRAY_BYTES",
                 "default": "epics.EPICS_CA_MAX_ARRAY_BYTES"
+              },
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
               }
             },
             "additionalProperties": false
@@ -41,6 +45,10 @@
                 "type": "string",
                 "const": "epics.EPICS_TS_MIN_WEST",
                 "default": "epics.EPICS_TS_MIN_WEST"
+              },
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
               }
             },
             "additionalProperties": false
@@ -60,6 +68,10 @@
                 "type": "string",
                 "const": "epics.dbpf",
                 "default": "epics.dbpf"
+              },
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
               }
             },
             "required": [
@@ -83,6 +95,10 @@
                 "type": "string",
                 "const": "epics.epicsEnvSet",
                 "default": "epics.epicsEnvSet"
+              },
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
               }
             },
             "required": [

--- a/tests/samples/schemas/pmac.schema.json
+++ b/tests/samples/schemas/pmac.schema.json
@@ -44,6 +44,10 @@
                 "type": "string",
                 "const": "pmac.Geobrick",
                 "default": "pmac.Geobrick"
+              },
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
               }
             },
             "required": [
@@ -71,6 +75,10 @@
                 "type": "string",
                 "const": "pmac.PmacAsynIPPort",
                 "default": "pmac.PmacAsynIPPort"
+              },
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
               }
             },
             "required": [
@@ -347,6 +355,10 @@
                 "type": "string",
                 "const": "pmac.DlsPmacAsynMotor",
                 "default": "pmac.DlsPmacAsynMotor"
+              },
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
               }
             },
             "required": [

--- a/tests/samples/schemas/pmac.schema.json
+++ b/tests/samples/schemas/pmac.schema.json
@@ -16,6 +16,10 @@
           {
             "type": "object",
             "properties": {
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
+              },
               "name": {
                 "type": "string",
                 "description": "Name to use for the geobrick's asyn port"
@@ -44,10 +48,6 @@
                 "type": "string",
                 "const": "pmac.Geobrick",
                 "default": "pmac.Geobrick"
-              },
-              "entity_disabled": {
-                "type": "boolean",
-                "default": false
               }
             },
             "required": [
@@ -63,6 +63,10 @@
           {
             "type": "object",
             "properties": {
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
+              },
               "name": {
                 "type": "string",
                 "description": "Asyn port name"
@@ -75,10 +79,6 @@
                 "type": "string",
                 "const": "pmac.PmacAsynIPPort",
                 "default": "pmac.PmacAsynIPPort"
-              },
-              "entity_disabled": {
-                "type": "boolean",
-                "default": false
               }
             },
             "required": [
@@ -90,6 +90,10 @@
           {
             "type": "object",
             "properties": {
+              "entity_disabled": {
+                "type": "boolean",
+                "default": false
+              },
               "PMAC": {
                 "type": "string",
                 "description": "PMAC to attach to"
@@ -355,10 +359,6 @@
                 "type": "string",
                 "const": "pmac.DlsPmacAsynMotor",
                 "default": "pmac.DlsPmacAsynMotor"
-              },
-              "entity_disabled": {
-                "type": "boolean",
-                "default": false
               }
             },
             "required": [

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -142,7 +142,12 @@ def test_entity_disabled_does_not_render_elements(pmac_classes, epics_classes):
     )
 
     # Make an IOC with our instances
-    ioc = IOC("TEST-IOC-01", "Test IOC", instance_list, "test_ioc_image",)
+    ioc = IOC(
+        "TEST-IOC-01",
+        "Test IOC",
+        instance_list,
+        "test_ioc_image",
+    )
 
     # Render script and check output
     expected_script = (

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -4,7 +4,16 @@ Entity classes
 """
 from unittest.mock import Mock
 
-from ibek.render import render_database, render_environment_variables, render_script
+from ibek.ioc import IOC
+from ibek.render import (
+    render_database,
+    render_database_elements,
+    render_environment_variable_elements,
+    render_environment_variables,
+    render_post_ioc_init_elements,
+    render_script,
+    render_script_elements,
+)
 
 
 def test_pmac_asyn_ip_port_script(pmac_classes):
@@ -74,3 +83,89 @@ def test_epics_environment_variables(epics_classes):
     env_text = render_environment_variables(epics_env_set_instance)
 
     assert env_text == f"epicsEnvSet \"{env_name}\", '{env_value}'"
+
+
+def test_entity_disabled_does_not_render_elements(pmac_classes, epics_classes):
+    # There are four elements to check: script, database, environment variables
+    # and post-iocInit
+
+    # Entity which has a script and database
+    pmac_geobrick_class = pmac_classes.Geobrick
+    # Entity which has env_vars
+    ca_max_array_bytes_class = epics_classes.EPICS_CA_MAX_ARRAY_BYTES
+    # Entity which has post_ioc_init
+    dbpf_class = epics_classes.dbpf
+
+    # We require pmac asyn IP port instances for the Geobrick class
+    pmac_asyn_ip_class = pmac_classes.PmacAsynIPPort
+    brick_one_asyn_ip_port = pmac_asyn_ip_class(
+        name="geobrick_one_port", IP="172.23.100.101"
+    )
+    brick_two_asyn_ip_port = pmac_asyn_ip_class(
+        name="geobrick_two_port", IP="172.23.100.101"
+    )
+
+    # Store created instances in a list
+    instance_list = []
+
+    # Create two instances of the Geobrick entity, one disabled
+    instance_list.append(
+        pmac_geobrick_class(
+            name="geobrick_enabled",
+            PORT=brick_one_asyn_ip_port,
+            P="geobrick_one",
+            numAxes=8,
+            idlePoll=200,
+            movingPoll=800,
+        )
+    )
+    instance_list.append(
+        pmac_geobrick_class(
+            name="geobrick_disabled",
+            PORT=brick_two_asyn_ip_port,
+            P="geobrick_two",
+            numAxes=8,
+            idlePoll=200,
+            movingPoll=800,
+            entity_disabled=True,
+        )
+    )
+
+    # Create two instances of the CA max array bytes entity, one disabled
+    instance_list.append(ca_max_array_bytes_class())
+    instance_list.append(ca_max_array_bytes_class(entity_disabled=True))
+
+    # Create two instances of the dpbf class
+    instance_list.append(dbpf_class(pv="TEST:PV:1", value="pv_value_1"))
+    instance_list.append(
+        dbpf_class(pv="TEST:PV:2", value="pv_value_2", entity_disabled=True)
+    )
+
+    # Make an IOC with our instances
+    ioc = IOC("TEST-IOC-01", "Test IOC", instance_list, "test_ioc_image",)
+
+    # Render script and check output
+    expected_script = (
+        "pmacCreateController(geobrick_enabled, geobrick_one_port, 0, 8, 800, 200)\n"
+        "pmacCreateAxes(geobrick_enabled, 8)\n"
+    )
+    script = render_script_elements(ioc)
+    assert script == expected_script
+
+    # Render database
+    expected_database = (
+        'dbLoadRecords("pmacController.template", "PMAC=geobrick_one")\n'
+        'dbLoadRecords("pmacStatus.template", "PMAC=geobrick_one")\n'
+    )
+    database = render_database_elements(ioc)
+    assert database == expected_database
+
+    # Render environment variables
+    expected_env_vars = "epicsEnvSet \"EPICS_CA_MAX_ARRAY_BYTES\", '6000000'\n"
+    env_vars = render_environment_variable_elements(ioc)
+    assert env_vars == expected_env_vars
+
+    # Render post_ioc_init
+    expected_post_ioc_init = 'dbpf "TEST:PV:1", "pv_value_1"\n'
+    post_ioc_init = render_post_ioc_init_elements(ioc)
+    assert post_ioc_init == expected_post_ioc_init


### PR DESCRIPTION
This is to fix #19.

Currently mypy complains because the base class Entity has no attribute entity_disabled - but if I add a type hint to this class then other unit tests fail due to an argument with a default value then being defined before a non-default argument.

I could ignore the check on that line but I was wondering if there was a real fix?