### PR TITLE
switch to using MSI for db expansion

### DIFF
--- a/src/ibek/__main__.py
+++ b/src/ibek/__main__.py
@@ -9,7 +9,13 @@ from ruamel.yaml import YAML
 
 from ibek import __version__
 
-from .helm import create_boot_script, create_helm, load_ioc_yaml
+from .helm import (
+    create_boot_script,
+    create_db_script,
+    create_helm,
+    ioc_deserialize,
+    load_ioc_yaml,
+)
 from .ioc import IOC, make_entity_classes
 from .support import Support
 
@@ -110,16 +116,25 @@ def build_startup(
         default="config/ioc.boot",
         help="Path to output startup script",
     ),
+    db_out: Path = typer.Option(
+        default="config/make_db.sh",
+        help="Path to output database expansion shell script",
+    ),
 ):
     """
     Build a startup script for an IOC instance
     """
-    script_txt = create_boot_script(
-        ioc_instance_yaml=instance, definition_yaml=definitions
-    )
+
+    ioc_instance = ioc_deserialize(instance, definitions)
+    script_txt = create_boot_script(ioc_instance)
 
     with out.open("w") as stream:
         stream.write(script_txt)
+
+    db_txt = create_db_script(ioc_instance)
+
+    with db_out.open("w") as stream:
+        stream.write(db_txt)
 
 
 # test with:

--- a/src/ibek/helm-template/config/start.sh
+++ b/src/ibek/helm-template/config/start.sh
@@ -29,4 +29,7 @@ boot=${config_dir}/ioc.boot
 # Output to /tmp for guarenteed writability
 msi -MTOP=${TOP},THIS_DIR=${config_dir},ADCORE=${adcore} ${boot} > /tmp/ioc.boot
 
+if [ -f make_db.sh ]; then
+    bash ./make_db.sh > /tmp/ioc.db
+fi
 exec ${IOC}/bin/linux-x86_64/ioc /tmp/ioc.boot

--- a/src/ibek/render.py
+++ b/src/ibek/render.py
@@ -48,6 +48,8 @@ def render_database(instance: Entity) -> Optional[str]:
     # include list entries expand to e.g. P={{ P }}
     jinja_arg = Template('{{ arg }}={{ "{{" + arg + "}}" }}')
 
+    # TODO review need for Jinja in include args
+    #   Jinja render define args then use fstring to combine
     for template in templates:
         db_file = template.file.strip("\n")
         db_args = template.define_args.splitlines()
@@ -56,7 +58,9 @@ def render_database(instance: Entity) -> Optional[str]:
         ]
         db_arg_string = ", ".join(db_args + include_list)
 
-        jinja_txt += f'dbLoadRecords("{db_file}", ' f'"{db_arg_string}")\n'
+        jinja_txt += (
+            f'msi -I${{EPICS_DB_INCLUDE_PATH}} -M"{db_arg_string}" "{db_file}"\n'
+        )
 
     jinja_template = Template(jinja_txt)
     db_txt = jinja_template.render(asdict(instance))

--- a/src/ibek/templates/ioc.boot.jinja
+++ b/src/ibek/templates/ioc.boot.jinja
@@ -6,7 +6,7 @@ dbLoadDatabase "dbd/ioc.dbd"
 ioc_registerRecordDeviceDriver(pdbbase)
 
 {{ script_elements }}
-{{ database_elements }}
+dbLoadRecords("/tmp/ioc.db")
 iocInit()
 {% if post_ioc_init_elements %}
 {{ post_ioc_init_elements -}}

--- a/src/ibek/templates/make_db.jinja
+++ b/src/ibek/templates/make_db.jinja
@@ -1,0 +1,2 @@
+#!/bin/bash
+{{ database_elements -}}

--- a/tests/samples/generate_samples.sh
+++ b/tests/samples/generate_samples.sh
@@ -13,28 +13,31 @@ export SAMPLES_DIR=$(realpath $(dirname "${BASH_SOURCE[0]}"))
 cd $SAMPLES_DIR
 
 echo making the global schema
-pipenv run ibek ibek-schema ${SAMPLES_DIR}/schemas/ibek.defs.schema.json
+ibek ibek-schema ${SAMPLES_DIR}/schemas/ibek.defs.schema.json
 
 echo making the epics definition schema
-pipenv run ibek ioc-schema ${SAMPLES_DIR}/yaml/epics.ibek.defs.yaml $SAMPLES_DIR/schemas/epics.ibek.defs.schema.json
+ibek ioc-schema ${SAMPLES_DIR}/yaml/epics.ibek.defs.yaml $SAMPLES_DIR/schemas/epics.ibek.defs.schema.json
 echo making the pmac support module definition schema
-pipenv run ibek ioc-schema ${SAMPLES_DIR}/yaml/pmac.ibek.defs.yaml $SAMPLES_DIR/schemas/pmac.ibek.entities.schema.json
+ibek ioc-schema ${SAMPLES_DIR}/yaml/pmac.ibek.defs.yaml $SAMPLES_DIR/schemas/pmac.ibek.entities.schema.json
 echo making the asyn support module definition schema
-pipenv run ibek ioc-schema ${SAMPLES_DIR}/yaml/asyn.ibek.defs.yaml $SAMPLES_DIR/schemas/asyn.ibek.entities.schema.json
+ibek ioc-schema ${SAMPLES_DIR}/yaml/asyn.ibek.defs.yaml $SAMPLES_DIR/schemas/asyn.ibek.entities.schema.json
 echo making a container definition schema
-pipenv run ibek ioc-schema ${SAMPLES_DIR}/yaml/asyn.ibek.defs.yaml ${SAMPLES_DIR}/yaml/pmac.ibek.defs.yaml $SAMPLES_DIR/schemas/container.ibek.entities.schema.json
+ibek ioc-schema ${SAMPLES_DIR}/yaml/asyn.ibek.defs.yaml ${SAMPLES_DIR}/yaml/pmac.ibek.defs.yaml $SAMPLES_DIR/schemas/container.ibek.entities.schema.json
 echo making a schema for bl45p-mo-ioc-04
-pipenv run ibek ioc-schema ${SAMPLES_DIR}/yaml/{epics,pmac}.ibek.defs.yaml $SAMPLES_DIR/schemas/bl45p-mo-ioc-04.ibek.entities.schema.json
+ibek ioc-schema ${SAMPLES_DIR}/yaml/{epics,pmac}.ibek.defs.yaml $SAMPLES_DIR/schemas/bl45p-mo-ioc-04.ibek.entities.schema.json
 
 # add --no-schema if needed (but above line should ensure that it is correct)
 echo making helm files
-pipenv run ibek build-helm ${SAMPLES_DIR}/yaml/bl45p-mo-ioc-02.ibek.entities.yaml /tmp/ioc
+ibek build-helm ${SAMPLES_DIR}/yaml/bl45p-mo-ioc-02.ibek.entities.yaml /tmp/ioc
 cp /tmp/ioc/bl45p-mo-ioc-02/values.yaml ${SAMPLES_DIR}/helm/
 cp /tmp/ioc/bl45p-mo-ioc-02/Chart.yaml ${SAMPLES_DIR}/helm/
 
 echo making startup script
-pipenv run ibek build-startup ${SAMPLES_DIR}/yaml/bl45p-mo-ioc-02.ibek.entities.yaml ${SAMPLES_DIR}/yaml/pmac.ibek.defs.yaml /tmp/ioc/ioc.boot
+ibek build-startup ${SAMPLES_DIR}/yaml/bl45p-mo-ioc-02.ibek.entities.yaml ${SAMPLES_DIR}/yaml/pmac.ibek.defs.yaml --out /tmp/ioc/ioc.boot --db-out /tmp/ioc/make_db.sh
 cp /tmp/ioc/ioc.boot ${SAMPLES_DIR}/helm/
-echo making multiple support module startup script
-pipenv run ibek build-startup ${SAMPLES_DIR}/yaml/bl45p-mo-ioc-03.ibek.entities.yaml ${SAMPLES_DIR}/yaml/pmac.ibek.defs.yaml ${SAMPLES_DIR}/yaml/asyn.ibek.defs.yaml /tmp/ioc/ioc.boot
+echo making bl45p-mo-ioc-03.boot
+ibek build-startup ${SAMPLES_DIR}/yaml/bl45p-mo-ioc-03.ibek.entities.yaml ${SAMPLES_DIR}/yaml/pmac.ibek.defs.yaml ${SAMPLES_DIR}/yaml/asyn.ibek.defs.yaml --out /tmp/ioc/ioc.boot --db-out /tmp/ioc/make_db.sh
 cp /tmp/ioc/ioc.boot ${SAMPLES_DIR}/helm/bl45p-mo-ioc-03.boot
+echo making bl45p-mo-ioc-04.boot
+ibek build-startup ${SAMPLES_DIR}/yaml/bl45p-mo-ioc-04.ibek.entities.yaml ${SAMPLES_DIR}/yaml/{epics,pmac}.ibek.defs.yaml --out /tmp/ioc/ioc.boot --db-out /tmp/ioc/make_db.sh
+cp /tmp/ioc/ioc.boot ${SAMPLES_DIR}/helm/bl45p-mo-ioc-04.boot

--- a/tests/samples/helm/bl45p-mo-ioc-03.boot
+++ b/tests/samples/helm/bl45p-mo-ioc-03.boot
@@ -10,9 +10,5 @@ TODO provide Jinja to generate Startup Entries
 note this is interesting because builder.py has a few if clauses
 for generating the necessary script
 
-dbLoadRecords("pmacController.template", "PMAC=BL45P-MO-STEP-01:")
-dbLoadRecords("pmacStatus.template", "PMAC=BL45P-MO-STEP-01:")
-dbLoadRecords("$(PMAC)/db/dls_pmac_asyn_motor.template", "ADDR=1, P=BL45P-MO-THIN-01, M=:X1, PORT=BL45P-MO-BRICK-01, DESC=, MRES=0.001, VELO=1.0, PREC=3.0, EGU=mm, TWV=1, DTYP=asynMotor, DIR=0, VBAS=1.0, VMAX=$(VELO), ACCL=0.5, BDST=0.0, BVEL=0.0, BACC=0.0, DHLM=10000.0, DLLM=, HLM=0.0, LLM=0.0, HLSV=MAJOR, INIT=, SREV=1000.0, RRES=0.0, ERES=0.0, JAR=0.0, UEIP=0, RDBL=0, RLINK=, RTRY=0, DLY=0.0, OFF=0.0, RDBD=0.0, FOFF=0, ADEL=0.0, NTM=1, FEHIGH=, FEHIHI=0.0, FEHHSV=NO_ALARM, FEHSV=NO_ALARM, SCALE=1, HOMEVIS=1, HOMEVISSTR=, name=X1 motor, alh=, gda_name=none, gda_desc=$(DESC), SPORT=BRICK1port, HOME=$(P), PMAC=BL45P-MO-BRICK-01, ALLOW_HOMED_SET=#")
-dbLoadRecords("$(PMAC)/db/dls_pmac_asyn_motor.template", "ADDR=2, P=BL45P-MO-THIN-01, M=:Y1, PORT=BL45P-MO-BRICK-01, DESC=, MRES=0.001, VELO=1.0, PREC=3.0, EGU=mm, TWV=1, DTYP=asynMotor, DIR=0, VBAS=1.0, VMAX=$(VELO), ACCL=0.5, BDST=0.0, BVEL=0.0, BACC=0.0, DHLM=10000.0, DLLM=, HLM=0.0, LLM=0.0, HLSV=MAJOR, INIT=, SREV=1000.0, RRES=0.0, ERES=0.0, JAR=0.0, UEIP=0, RDBL=0, RLINK=, RTRY=0, DLY=0.0, OFF=0.0, RDBD=0.0, FOFF=0, ADEL=0.0, NTM=1, FEHIGH=, FEHIHI=0.0, FEHHSV=NO_ALARM, FEHSV=NO_ALARM, SCALE=1, HOMEVIS=1, HOMEVISSTR=, name=Y1 motor, alh=, gda_name=none, gda_desc=$(DESC), SPORT=BRICK1port, HOME=$(P), PMAC=BL45P-MO-BRICK-01, ALLOW_HOMED_SET=#")
-
+dbLoadRecords("/tmp/ioc.db")
 iocInit()

--- a/tests/samples/helm/bl45p-mo-ioc-04.boot
+++ b/tests/samples/helm/bl45p-mo-ioc-04.boot
@@ -1,22 +1,10 @@
 cd "$(TOP)"
 
-epicsEnvSet "EPICS_CA_MAX_ARRAY_BYTES", '6000000'
-epicsEnvSet "EPICS_TS_MIN_WEST", '60'
-epicsEnvSet "EPICS_CA_SERVER_PORT", '5010'
-
 dbLoadDatabase "dbd/ioc.dbd"
 ioc_registerRecordDeviceDriver(pdbbase)
 
-pmacAsynIPConfigure(BRICK1port, 192.168.0.12:1112)
-pmacCreateController(BL45P-MO-BRICK-01, BRICK1port, 0, 8, 500, 100)
-pmacCreateAxes(BL45P-MO-BRICK-01, 8)
 
-dbLoadRecords("pmacController.template", "PMAC=BL45P-MO-STEP-01:")
-dbLoadRecords("pmacStatus.template", "PMAC=BL45P-MO-STEP-01:")
-dbLoadRecords("$(PMAC)/db/dls_pmac_asyn_motor.template", "ADDR=1, P=BL45P-MO-THIN-01, M=:X1, PORT=BL45P-MO-BRICK-01, DESC=, MRES=0.001, VELO=1.0, PREC=3.0, EGU=mm, TWV=1, DTYP=asynMotor, DIR=0, VBAS=1.0, VMAX=$(VELO), ACCL=0.5, BDST=0.0, BVEL=0.0, BACC=0.0, DHLM=10000.0, DLLM=, HLM=0.0, LLM=0.0, HLSV=MAJOR, INIT=, SREV=1000.0, RRES=0.0, ERES=0.0, JAR=0.0, UEIP=0, RDBL=0, RLINK=, RTRY=0, DLY=0.0, OFF=0.0, RDBD=0.0, FOFF=0, ADEL=0.0, NTM=1, FEHIGH=, FEHIHI=0.0, FEHHSV=NO_ALARM, FEHSV=NO_ALARM, SCALE=1, HOMEVIS=1, HOMEVISSTR=, name=X1 motor, alh=, gda_name=none, gda_desc=$(DESC), SPORT=BRICK1port, HOME=$(P), PMAC=BL45P-MO-BRICK-01, ALLOW_HOMED_SET=#")
-dbLoadRecords("$(PMAC)/db/dls_pmac_asyn_motor.template", "ADDR=2, P=BL45P-MO-THIN-01, M=:Y1, PORT=BL45P-MO-BRICK-01, DESC=, MRES=0.001, VELO=1.0, PREC=3.0, EGU=mm, TWV=1, DTYP=asynMotor, DIR=0, VBAS=1.0, VMAX=$(VELO), ACCL=0.5, BDST=0.0, BVEL=0.0, BACC=0.0, DHLM=10000.0, DLLM=, HLM=0.0, LLM=0.0, HLSV=MAJOR, INIT=, SREV=1000.0, RRES=0.0, ERES=0.0, JAR=0.0, UEIP=0, RDBL=0, RLINK=, RTRY=0, DLY=0.0, OFF=0.0, RDBD=0.0, FOFF=0, ADEL=0.0, NTM=1, FEHIGH=, FEHIHI=0.0, FEHHSV=NO_ALARM, FEHSV=NO_ALARM, SCALE=1, HOMEVIS=1, HOMEVISSTR=, name=Y1 motor, alh=, gda_name=none, gda_desc=$(DESC), SPORT=BRICK1port, HOME=$(P), PMAC=BL45P-MO-BRICK-01, ALLOW_HOMED_SET=#")
-
+dbLoadRecords("/tmp/ioc.db")
 iocInit()
 
-dbpf "BL45P-MO-THIN-01:X1.TWV", "2.5"
 dbpf "BL45P-MO-THIN-01:Y1.TWV", "0.5"

--- a/tests/samples/helm/ioc.boot
+++ b/tests/samples/helm/ioc.boot
@@ -7,9 +7,5 @@ pmacAsynIPConfigure(BRICK1port, 192.168.0.12:1112)
 pmacCreateController(BL45P-MO-BRICK-01, BRICK1port, 0, 8, 500, 100)
 pmacCreateAxes(BL45P-MO-BRICK-01, 8)
 
-dbLoadRecords("pmacController.template", "PMAC=BL45P-MO-STEP-01:")
-dbLoadRecords("pmacStatus.template", "PMAC=BL45P-MO-STEP-01:")
-dbLoadRecords("$(PMAC)/db/dls_pmac_asyn_motor.template", "ADDR=1, P=BL45P-MO-THIN-01, M=:X1, PORT=BL45P-MO-BRICK-01, DESC=, MRES=0.001, VELO=1.0, PREC=3.0, EGU=mm, TWV=1, DTYP=asynMotor, DIR=0, VBAS=1.0, VMAX=$(VELO), ACCL=0.5, BDST=0.0, BVEL=0.0, BACC=0.0, DHLM=10000.0, DLLM=, HLM=0.0, LLM=0.0, HLSV=MAJOR, INIT=, SREV=1000.0, RRES=0.0, ERES=0.0, JAR=0.0, UEIP=0, RDBL=0, RLINK=, RTRY=0, DLY=0.0, OFF=0.0, RDBD=0.0, FOFF=0, ADEL=0.0, NTM=1, FEHIGH=, FEHIHI=0.0, FEHHSV=NO_ALARM, FEHSV=NO_ALARM, SCALE=1, HOMEVIS=1, HOMEVISSTR=, name=X1 motor, alh=, gda_name=none, gda_desc=$(DESC), SPORT=BRICK1port, HOME=$(P), PMAC=BL45P-MO-BRICK-01, ALLOW_HOMED_SET=#")
-dbLoadRecords("$(PMAC)/db/dls_pmac_asyn_motor.template", "ADDR=2, P=BL45P-MO-THIN-01, M=:Y1, PORT=BL45P-MO-BRICK-01, DESC=, MRES=0.001, VELO=1.0, PREC=3.0, EGU=mm, TWV=1, DTYP=asynMotor, DIR=0, VBAS=1.0, VMAX=$(VELO), ACCL=0.5, BDST=0.0, BVEL=0.0, BACC=0.0, DHLM=10000.0, DLLM=, HLM=0.0, LLM=0.0, HLSV=MAJOR, INIT=, SREV=1000.0, RRES=0.0, ERES=0.0, JAR=0.0, UEIP=0, RDBL=0, RLINK=, RTRY=0, DLY=0.0, OFF=0.0, RDBD=0.0, FOFF=0, ADEL=0.0, NTM=1, FEHIGH=, FEHIHI=0.0, FEHHSV=NO_ALARM, FEHSV=NO_ALARM, SCALE=1, HOMEVIS=1, HOMEVISSTR=, name=Y1 motor, alh=, gda_name=none, gda_desc=$(DESC), SPORT=BRICK1port, HOME=$(P), PMAC=BL45P-MO-BRICK-01, ALLOW_HOMED_SET=#")
-
+dbLoadRecords("/tmp/ioc.db")
 iocInit()

--- a/tests/samples/yaml/bl45p-mo-ioc-04.ibek.entities.yaml
+++ b/tests/samples/yaml/bl45p-mo-ioc-04.ibek.entities.yaml
@@ -1,54 +1,52 @@
-# yaml-language-server: $schema=file://tests/samples/schemas/bl45p-mo-ioc-04.ibek.entities.schema.json
+# yaml-language-server: $schema=../schemas/bl45p-mo-ioc-04.ibek.entities.schema.json
 ioc_name: bl45p-mo-ioc-04
 description: an example motion ioc with epics environment variables and dbpf entries
 generic_ioc_image: ghcr.io/epics-containers/ioc-pmac:main.run
 entities:
-  - type: epics.EPICS_CA_MAX_ARRAY_BYTES
+  # - type: epics.EPICS_CA_MAX_ARRAY_BYTES
   
-  - type: epics.EPICS_TS_MIN_WEST
-    minutes_west: 60
+  # - type: epics.EPICS_TS_MIN_WEST
+  #   minutes_west: 60
 
-  - type: epics.epicsEnvSet
-    name: EPICS_CA_SERVER_PORT
-    value: "5010"
+  # - type: epics.epicsEnvSet
+  #   name: EPICS_CA_SERVER_PORT
+  #   value: "5010"
 
-  - type: pmac.PmacAsynIPPort
-    name: BRICK1port
-    IP: 192.168.0.12:1112
+  # - type: pmac.PmacAsynIPPort
+  #   name: BRICK1port
+  #   IP: 192.168.0.12:1112
 
-  - type: pmac.Geobrick
-    name: BL45P-MO-BRICK-01
-    PORT: BRICK1port
-    P: "BL45P-MO-STEP-01:"
-    numAxes: 8
-    idlePoll: 100
-    movingPoll: 500
+  # - type: pmac.Geobrick
+  #   name: BL45P-MO-BRICK-01
+  #   PORT: BRICK1port
+  #   P: "BL45P-MO-STEP-01:"
+  #   numAxes: 8
+  #   idlePoll: 100
+  #   movingPoll: 500
 
-  - type: pmac.DlsPmacAsynMotor
-    name: X1 motor
-    # TODO previously would have been an object pointing to a pmac.Geobrick
-    PMAC: BL45P-MO-BRICK-01
-    # TODO Previously would have used pmac.PORT, pmac.SPORT
-    PORT: BL45P-MO-BRICK-01
-    SPORT: BRICK1port
-    axis: 1
-    P: BL45P-MO-THIN-01
-    M: ":X1"
-    MRES: 0.001
+  # - type: pmac.DlsPmacAsynMotor
+  #   name: X1 motor
+  #   PMAC: BL45P-MO-BRICK-01
+  #   PORT: BL45P-MO-BRICK-01
+  #   SPORT: BRICK1port
+  #   axis: 1
+  #   P: BL45P-MO-THIN-01
+  #   M: ":X1"
+  #   MRES: 0.001
 
-  - type: pmac.DlsPmacAsynMotor
-    name: Y1 motor
-    PMAC: BL45P-MO-BRICK-01
-    PORT: BL45P-MO-BRICK-01
-    SPORT: BRICK1port
-    axis: 2
-    P: BL45P-MO-THIN-01
-    M: ":Y1"
-    MRES: 0.001
+  # - type: pmac.DlsPmacAsynMotor
+  #   name: Y1 motor
+  #   PMAC: BL45P-MO-BRICK-01
+  #   PORT: BL45P-MO-BRICK-01
+  #   SPORT: BRICK1port
+  #   axis: 2
+  #   P: BL45P-MO-THIN-01
+  #   M: ":Y1"
+  #   MRES: 0.001
 
-  - type: epics.dbpf
-    pv: BL45P-MO-THIN-01:X1.TWV
-    value: "2.5"
+  # - type: epics.dbpf
+  #   pv: BL45P-MO-THIN-01:X1.TWV
+  #   value: "2.5"
   
   - type: epics.dbpf
     pv: BL45P-MO-THIN-01:Y1.TWV

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -120,8 +120,17 @@ def test_build_startup_single(tmp_path: Path, samples: Path):
     entity_file = samples / "yaml" / "bl45p-mo-ioc-02.ibek.entities.yaml"
     definition_file = samples / "yaml" / "pmac.ibek.defs.yaml"
     out_file = tmp_path / "ioc.boot"
+    out_db = tmp_path / "make_db.sh"
 
-    run_cli("build-startup", entity_file, definition_file, "--out", out_file)
+    run_cli(
+        "build-startup",
+        entity_file,
+        definition_file,
+        "--out",
+        out_file,
+        "--db-out",
+        out_db,
+    )
 
     example_boot = (samples / "helm" / "ioc.boot").read_text()
     actual_boot = out_file.read_text()
@@ -139,6 +148,7 @@ def test_build_startup_multiple(tmp_path: Path, samples: Path):
     definition_file1 = samples / "yaml" / "asyn.ibek.defs.yaml"
     definition_file2 = samples / "yaml" / "pmac.ibek.defs.yaml"
     out_file = tmp_path / "ioc.boot"
+    out_db = tmp_path / "make_db.sh"
 
     run_cli(
         "build-startup",
@@ -147,6 +157,8 @@ def test_build_startup_multiple(tmp_path: Path, samples: Path):
         definition_file2,
         "--out",
         out_file,
+        "--db-out",
+        out_db,
     )
 
     example_boot = (samples / "helm" / "bl45p-mo-ioc-03.boot").read_text()
@@ -166,6 +178,7 @@ def test_build_startup_env_vars_and_post_ioc_init(tmp_path: Path, samples: Path)
     definition_file1 = samples / "yaml" / "epics.ibek.defs.yaml"
     definition_file2 = samples / "yaml" / "pmac.ibek.defs.yaml"
     out_file = tmp_path / "ioc.boot"
+    out_db = tmp_path / "make_db.sh"
 
     run_cli(
         "build-startup",
@@ -174,6 +187,8 @@ def test_build_startup_env_vars_and_post_ioc_init(tmp_path: Path, samples: Path)
         definition_file2,
         "--out",
         out_file,
+        "--db-out",
+        out_db,
     )
 
     example_boot = (samples / "helm" / "bl45p-mo-ioc-04.boot").read_text()

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -60,8 +60,10 @@ def test_geobrick_database(pmac_classes):
     db_txt = render_database(pmac_geobrick_instance)
 
     assert (
-        db_txt == 'dbLoadRecords("pmacController.template", "PMAC=geobrick_one")\n'
-        'dbLoadRecords("pmacStatus.template", "PMAC=geobrick_one")'
+        db_txt == 'msi -I${EPICS_DB_INCLUDE_PATH} -M"PMAC=geobrick_one"'
+        ' "pmacController.template"\n'
+        'msi -I${EPICS_DB_INCLUDE_PATH} -M"PMAC=geobrick_one"'
+        ' "pmacStatus.template"'
     )
 
 
@@ -159,8 +161,9 @@ def test_entity_disabled_does_not_render_elements(pmac_classes, epics_classes):
 
     # Render database
     expected_database = (
-        'dbLoadRecords("pmacController.template", "PMAC=geobrick_one")\n'
-        'dbLoadRecords("pmacStatus.template", "PMAC=geobrick_one")\n'
+        'msi -I${EPICS_DB_INCLUDE_PATH} -M"PMAC=geobrick_one"'
+        ' "pmacController.template"\n'
+        'msi -I${EPICS_DB_INCLUDE_PATH} -M"PMAC=geobrick_one" "pmacStatus.template"\n'
     )
     database = render_database_elements(ioc)
     assert database == expected_database

--- a/tests/test_temp.py
+++ b/tests/test_temp.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from ibek.__main__ import cli
+from ibek.ioc import clear_entity_classes
+
+runner = CliRunner()
+
+
+def run_cli(*args):
+    result = runner.invoke(cli, [str(x) for x in args])
+    if result.exception:
+        raise result.exception
+    assert result.exit_code == 0, result
+
+
+"""
+A test for debugging the creation of startup scripts
+remove xx to run this in debug mode.
+"""
+
+
+def xxtest_build_startup_p45(tmp_path: Path, samples: Path):
+    """
+    build an ioc startup script from an IOC instance entity file
+    and multiple support module definition files
+    """
+    root = Path("/workspace/bl45p")
+
+    clear_entity_classes()
+    entity_file = root / "bl45p-mo-ioc-99.yaml"
+    definitions = Path.glob(root / "ibek", "*.ibek.defs.yaml")
+    out_file = root / "iocs/bl45p-mo-ioc-99/config/ioc.boot"
+
+    run_cli("build-startup", entity_file, *definitions, "--out", out_file)


### PR DESCRIPTION
This PR adds the generation of an extra script in the ioc config folder called make_db.sh.

The script uses msi to do macro substitution for each 'database' entry in the ioc yaml and output an expanded database file.
