### PR TITLE
enable ibek build-startup support in start.sh

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -118,14 +118,19 @@ jobs:
           name: ${{ matrix.python }}/${{ matrix.os }}/${{ matrix.lock }}
           files: cov.xml
 
-      - name: Upload lockfiles
+      - name: Generate ibek.defs.schema.json
+        run: |
+          ibek ibek-schema ibek.defs.schema.json
+
+      - name: Upload build files
         if: matrix.lock
         uses: actions/upload-artifact@v2
         with:
-          name: lockfiles
+          name: buildfiles
           path: |
             requirements.txt
             requirements_dev.txt
+            ibek.defs.schema.json
 
   release:
     needs: [lint, wheel, test]
@@ -144,7 +149,7 @@ jobs:
         with:
           files: |
             artifacts/dist/*
-            artifacts/lockfiles/*
+            artifacts/buildfiles/*
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/ibek/helm-template/config/start.sh
+++ b/src/ibek/helm-template/config/start.sh
@@ -7,13 +7,15 @@ this_dir=$(realpath $(dirname $0))
 TOP=$(realpath ${this_dir}/..)
 cd ${this_dir}
 
+set -x -e
+
 # add module paths to environment for use in ioc startup script
 source ${SUPPORT}/configure/RELEASE.shell
 
 # if there is a non-zero length config.tz then decompress into config_untar
 if [ -s config.tz ]
 then
-    # decompress the configuration files into config_untar (/tmp is always writeable)
+    # decompress the configuration files into config_untar (/tmp is writeable)
     config_dir=/tmp/config_untar
 
     mkdir -p ${config_dir}
@@ -22,14 +24,26 @@ else
     config_dir=${TOP}/config
 fi
 
-boot=${config_dir}/ioc.boot
+# setup filenames for boot scripts
+startup_src=${config_dir}/ioc.boot.yaml
+boot_src=${config_dir}/ioc.boot
+db_src=/tmp/make_db.sh
+boot=/tmp/$(basename ${boot_src})
+db=/tmp/ioc.db
 
-# Update the boot script to work in the directory it resides in
-# using msi MACRO substitution.
-# Output to /tmp for guarenteed writability
-msi -MTOP=${TOP},THIS_DIR=${config_dir},ADCORE=${adcore} ${boot} > /tmp/ioc.boot
+# If there is a yaml ioc description then generate the startup and DB.
+# Otherwise assume the starup script ioc.boot is provided in the config folder.
+if [ -f ${startup_src} ] ; then
+    # get ibek defs files from this ioc and all support modules and this IOC
+    # defs="${SUPPORT}/*/ibek/*.ibek.defs.yaml ${TOP}/ibek/*.ibek.defs.yaml"
 
-if [ -f make_db.sh ]; then
-    bash ./make_db.sh > /tmp/ioc.db
+    # TODO - for early development we ship all latest def files in ioc/ibek
+    defs=${TOP}/ibek/*.ibek.defs.yaml
+    ibek build-startup ${startup_src} ${defs} --out ${boot} --db-out ${db_src}
 fi
-exec ${IOC}/bin/linux-x86_64/ioc /tmp/ioc.boot
+
+# build expanded database using the db_src shell script
+if [ -f ${db_src} ]; then
+    bash ${db_src} > ${db}
+fi
+exec ${IOC}/bin/linux-x86_64/ioc ${boot}

--- a/src/ibek/templates/ioc.boot.jinja
+++ b/src/ibek/templates/ioc.boot.jinja
@@ -1,4 +1,4 @@
-cd "$(TOP)"
+cd "/repos/epics/ioc"
 {% if env_var_elements %}
 {{ env_var_elements -}}
 {% endif %}

--- a/tests/samples/helm/bl45p-mo-ioc-03.boot
+++ b/tests/samples/helm/bl45p-mo-ioc-03.boot
@@ -1,4 +1,4 @@
-cd "$(TOP)"
+cd "/repos/epics/ioc"
 
 dbLoadDatabase "dbd/ioc.dbd"
 ioc_registerRecordDeviceDriver(pdbbase)

--- a/tests/samples/helm/bl45p-mo-ioc-04.boot
+++ b/tests/samples/helm/bl45p-mo-ioc-04.boot
@@ -1,4 +1,4 @@
-cd "$(TOP)"
+cd "/repos/epics/ioc"
 
 dbLoadDatabase "dbd/ioc.dbd"
 ioc_registerRecordDeviceDriver(pdbbase)

--- a/tests/samples/helm/ioc.boot
+++ b/tests/samples/helm/ioc.boot
@@ -1,4 +1,4 @@
-cd "$(TOP)"
+cd "/repos/epics/ioc"
 
 dbLoadDatabase "dbd/ioc.dbd"
 ioc_registerRecordDeviceDriver(pdbbase)


### PR DESCRIPTION
Changes to the start.sh in the template helm chart to make it look for an ibek ioc yaml file and expand that into a startup script (and make_db script).

Also added CI step to publish ibek.defs.schema.json as an Asset