### PR TITLE
add values support (broken)

### DIFF
--- a/src/ibek/support.py
+++ b/src/ibek/support.py
@@ -140,6 +140,18 @@ class Once:
 
 
 @dataclass
+class Value:
+    """A calculated string value for a definition"""
+
+    name: A[str, desc("Name of the value that the IOC instance will expose")]
+    description: A[str, desc("Description of what the value will be used for")]
+    value: A[str, desc("The contents of the value")]
+
+    def __str__(self):
+        return self.value
+
+
+@dataclass
 class Definition:
     """
     A single definition of a class of Entity that an IOC instance may instantiate
@@ -148,6 +160,7 @@ class Definition:
     name: A[str, desc("Publish Definition as type <module>.<name> for IOC instances")]
     description: A[str, desc("Describes the purpose of the definition")]
     args: A[Sequence[Arg], desc("The arguments IOC instance should supply")] = ()
+    values: A[Sequence[Value], desc("The values IOC instance should supply")] = ()
     databases: A[Sequence[Database], desc("Databases to instantiate")] = ()
     script: A[
         Sequence[Union[str, Function, Once]],

--- a/tests/samples/example-srrfioc08/st.cmd
+++ b/tests/samples/example-srrfioc08/st.cmd
@@ -15,7 +15,7 @@ ioc_registerRecordDeviceDriver pdbbase
 #   Create a new Hy8002 carrier.
 #   The resulting carrier handle is saved in an env variable.
 ipacAddHy8002 "4, 2" 
-epicsEnvSet IPAC4 0
+epicsEnvSet IPAC4 
 
 # Hy8401ipConfigure CardId IPACid IpSiteNumber InterruptVector InterruptEnable AiType ExternalClock ClockRate Inhibit SampleCount SampleSpacing SampleSize 
 #   IpSlot 0=A 1=B 2=C 3=D

--- a/tests/samples/schemas/ibek.defs.schema.json
+++ b/tests/samples/schemas/ibek.defs.schema.json
@@ -207,6 +207,34 @@
             "description": "The arguments IOC instance should supply",
             "default": []
           },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Name of the value that the IOC instance will expose"
+                },
+                "description": {
+                  "type": "string",
+                  "description": "Description of what the value will be used for"
+                },
+                "value": {
+                  "type": "string",
+                  "description": "The contents of the value"
+                }
+              },
+              "required": [
+                "name",
+                "description",
+                "value"
+              ],
+              "additionalProperties": false
+            },
+            "description": "The values IOC instance should supply",
+            "default": []
+          },
           "databases": {
             "type": "array",
             "items": {


### PR DESCRIPTION
I'm struggling with implementing 'values' calculated fields.

The example I want to render is https://github.com/epics-containers/ibek-defs/blob/psc/ipac/ipac.ibek.support.yaml.

I first tried adding the values in as defaulted Args in make_entity_class. But this interfered with the schema - so you could see the entry and override it just like it was an Arg (I suppose we could call that a feature but its not clear that you are not supposed to supply a value for it).

Next I decided to just copy the values into all instances in ioc_deserialize. The current PR shows this. It does not work because converting the instance to Dict for Jinja does not pick up the new attributes because they are not in __dataclass_fields__. I could fix that I suppose but it is feeling really nasty.

@coretl I wondered if you had ideas on how to do this nicely.

(Values should really be a class variable that gets passed to all entity instances but is not needed in ioc yaml. If there is a nice way to do this it might need to change with the Pydantic update.)