### PR TITLE
switch to Entity.__dict__ instead of __context__

### DIFF
--- a/src/ibek/render.py
+++ b/src/ibek/render.py
@@ -43,7 +43,7 @@ class Render:
 
         # Render Jinja entries in the text
         jinja_template = Template(text)
-        result = jinja_template.render(instance.__context__)  # type: ignore
+        result = jinja_template.render(instance.__dict__)  # type: ignore
 
         if result == "":
             return ""
@@ -107,7 +107,7 @@ class Render:
 
             include_list = []
             for arg in template.include_args:
-                if arg in instance.__context__:
+                if arg in instance.__dict__:
                     include_list.append(f"{arg}={{{{ {arg} }}}}")
                 else:
                     raise ValueError(
@@ -122,12 +122,12 @@ class Render:
             )
 
         jinja_template = Template(jinja_txt)
-        db_txt = jinja_template.render(instance.__context__)  # type: ignore
+        db_txt = jinja_template.render(instance.__dict__)  # type: ignore
 
         # run the result through jinja again so we can refer to args for arg defaults
 
         db_template = Template(db_txt)
-        db_txt = db_template.render(instance.__context__)  # type: ignore
+        db_txt = db_template.render(instance.__dict__)  # type: ignore
 
         return db_txt + "\n"
 
@@ -144,7 +144,7 @@ class Render:
         for variable in variables:
             # Substitute the name and value of the environment variable from args
             env_template = Template(f"epicsEnvSet {variable.name} {variable.value}")
-            env_var_txt += env_template.render(instance.__context__)
+            env_var_txt += env_template.render(instance.__dict__)
         return env_var_txt + "\n"
 
     def render_post_ioc_init(self, instance: Entity) -> Optional[str]:

--- a/src/ibek/render.py
+++ b/src/ibek/render.py
@@ -124,11 +124,6 @@ class Render:
         jinja_template = Template(jinja_txt)
         db_txt = jinja_template.render(instance.__dict__)  # type: ignore
 
-        # run the result through jinja again so we can refer to args for arg defaults
-
-        db_template = Template(db_txt)
-        db_txt = db_template.render(instance.__dict__)  # type: ignore
-
         return db_txt + "\n"
 
     def render_environment_variables(self, instance: Entity) -> Optional[str]:

--- a/src/ibek/utils.py
+++ b/src/ibek/utils.py
@@ -76,3 +76,7 @@ class Utils:
         self.counters[name] = counter
 
         return result
+
+
+# a singleton Utility object for sharing state across all Entity renders
+UTILS: Utils = Utils()

--- a/tests/samples/schemas/all.ibek.support.schema.json
+++ b/tests/samples/schemas/all.ibek.support.schema.json
@@ -1349,9 +1349,9 @@
                 "type": "boolean",
                 "default": true
               },
-              "device": {
+              "name": {
                 "type": "string",
-                "description": "Device Name, channel name until the last colon, up to 16 chars",
+                "description": "A name this IP module",
                 "vscode_ibek_plugin_type": "type_id"
               },
               "carrier": {
@@ -1380,7 +1380,7 @@
               }
             },
             "required": [
-              "device",
+              "name",
               "carrier",
               "ip_site_number",
               "interrupt_vector"
@@ -1393,6 +1393,20 @@
               "entity_enabled": {
                 "type": "boolean",
                 "default": true
+              },
+              "device": {
+                "type": "string",
+                "description": "Device Name, PV Suffix",
+                "vscode_ibek_plugin_type": "type_id"
+              },
+              "ip_module": {
+                "type": "string",
+                "description": "PscIpModule object",
+                "vscode_ibek_plugin_type": "type_object"
+              },
+              "link": {
+                "type": "integer",
+                "description": "Link number on this IP module (0 or 1)"
               },
               "i_abserr": {
                 "type": "integer",
@@ -1480,6 +1494,11 @@
                 "default": "psc.PscTemplate"
               }
             },
+            "required": [
+              "device",
+              "ip_module",
+              "link"
+            ],
             "additionalProperties": false
           },
           {

--- a/tests/test_ioc.py
+++ b/tests/test_ioc.py
@@ -2,7 +2,8 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
-from ibek.ioc import Entity, clear_entity_classes
+from ibek.ioc import clear_entity_classes
+from ibek.utils import UTILS
 
 from .test_cli import run_cli
 
@@ -18,7 +19,7 @@ def test_example_ioc(tmp_path: Path, samples: Path, ibek_defs: Path):
     verifies that it starts up correctly.
     """
     clear_entity_classes()
-    Entity.__utils__.__reset__()
+    UTILS.__reset__()
 
     tmp_path = Path("/tmp/ibek_test")
     tmp_path.mkdir(exist_ok=True)
@@ -60,7 +61,7 @@ def test_example_sr_rf_08(tmp_path: Path, samples: Path, ibek_defs: Path):
     """
 
     clear_entity_classes()
-    Entity.__utils__.__reset__()
+    UTILS.__reset__()
 
     tmp_path = Path("/tmp/ibek_test2")
     tmp_path.mkdir(exist_ok=True)
@@ -104,7 +105,7 @@ def test_values_ioc(tmp_path: Path, samples: Path, ibek_defs: Path):
     """
 
     clear_entity_classes()
-    Entity.__utils__.__reset__()
+    UTILS.__reset__()
 
     tmp_path = Path("/tmp/ibek_test2")
     tmp_path.mkdir(exist_ok=True)


### PR DESCRIPTION
Tidy up the approach of passing Entity attributes to Jinja context. Including how 'values' fields are added.

All values for the jinja context are now just ordinary attributes on Entity and area passed using __dict__.