### PR TITLE
make schema check for missing non-defaulted args

### DIFF
--- a/src/ibek/ioc.py
+++ b/src/ibek/ioc.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Literal, Sequence, Tuple, Type, Union
 
 from pydantic import Field, RootModel, create_model, field_validator, model_validator
 from pydantic.fields import FieldInfo
+from pydantic_core import PydanticUndefined
 
 from .globals import BaseSettings, render_with_utils
 from .support import Definition, EnumArg, IdArg, ObjectArg, Support
@@ -69,10 +70,12 @@ def make_entity_model(definition: Definition, support: Support) -> Type[Entity]:
     Create an Entity Model from a Definition instance and a Support instance.
     """
 
-    def add_arg(name, typ, description, default, options=None):
+    def add_arg(name, typ, description, default):
+        if default is None:
+            default = PydanticUndefined
         args[name] = (
             typ,
-            FieldInfo(description=description, default=default, options=options),
+            FieldInfo(description=description, default=default),
         )
 
     args: Dict[str, Tuple[type, Any]] = {}

--- a/tests/samples/outputs/all.st.cmd
+++ b/tests/samples/outputs/all.st.cmd
@@ -12,17 +12,23 @@ ioc_registerRecordDeviceDriver pdbbase
 TestValues Ref1.127.0.0.1
 
 # testPreInit identifier TestValue
-testPreInit A Consumer test_value:
-The value of my_inferred_enum is third
-The value of clock_rate is dummy
-testPreInit Another Consumer test_value:
-The value of my_inferred_enum is hello
-The value of clock_rate is 1
+testPreInit AllObject One 'AllObject One String'
+my_str =                    AllObject One String
+my_inferred_enum =          third
+clock_rate =                dummy
+my_mixed_enum_no_default =  
+.
+testPreInit AllObject Two 'AllObject Two String'
+my_str =                    AllObject Two String
+my_inferred_enum =          hello
+clock_rate =                1
+my_mixed_enum_no_default =  
+.
 
 dbLoadRecords /tmp/ioc.db
 iocInit
 
 
-testPostInit A Consumer test_value:
-testPostInit Another Consumer test_value:
+testPostInit AllObject One test_value:
+testPostInit AllObject Two test_value:
 

--- a/tests/samples/schemas/multiple.ibek.ioc.schema.json
+++ b/tests/samples/schemas/multiple.ibek.ioc.schema.json
@@ -53,7 +53,6 @@
           "type": "boolean"
         },
         "name": {
-          "default": null,
           "description": "identifier",
           "title": "Name",
           "type": "string"
@@ -67,22 +66,12 @@
           "default": 2,
           "description": "integer enumerated type"
         },
-        "my_mixed_enum": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/my_mixed_enum"
-            }
-          ],
-          "default": null,
-          "description": "mixed enumerated type"
-        },
         "my_inferred_enum": {
           "allOf": [
             {
               "$ref": "#/$defs/my_inferred_enum"
             }
           ],
-          "default": null,
           "description": "integer enumerated type with inferred value"
         },
         "clock_rate": {
@@ -91,11 +80,9 @@
               "$ref": "#/$defs/clock_rate"
             }
           ],
-          "default": null,
           "description": "demonstrates use of VME clock rates as an enum\nthis is an example of an 'illegal' python enum\n"
         },
         "my_str": {
-          "default": null,
           "description": "string arg",
           "title": "My Str",
           "type": "string"
@@ -107,7 +94,6 @@
           "type": "integer"
         },
         "my_object": {
-          "default": null,
           "description": "object arg",
           "title": "My Object"
         },
@@ -130,6 +116,13 @@
           "type": "string"
         }
       },
+      "required": [
+        "name",
+        "my_inferred_enum",
+        "clock_rate",
+        "my_str",
+        "my_object"
+      ],
       "title": "module_AllObject",
       "type": "object"
     },
@@ -152,15 +145,6 @@
       "title": "my_int_enum",
       "type": "string"
     },
-    "my_mixed_enum": {
-      "enum": [
-        "first",
-        "second",
-        "third"
-      ],
-      "title": "my_mixed_enum",
-      "type": "string"
-    },
     "object_module_Consumer": {
       "additionalProperties": false,
       "properties": {
@@ -177,17 +161,19 @@
           "type": "boolean"
         },
         "name": {
-          "default": null,
           "description": "Consumer name",
           "title": "Name",
           "type": "string"
         },
         "PORT": {
-          "default": null,
           "description": "a reference to an RefObject",
           "title": "Port"
         }
       },
+      "required": [
+        "name",
+        "PORT"
+      ],
       "title": "object_module_Consumer",
       "type": "object"
     },
@@ -207,17 +193,19 @@
           "type": "boolean"
         },
         "name": {
-          "default": null,
           "description": "Consumer name",
           "title": "Name",
           "type": "string"
         },
         "PORT": {
-          "default": null,
           "description": "a reference to an RefObject",
           "title": "Port"
         }
       },
+      "required": [
+        "name",
+        "PORT"
+      ],
       "title": "object_module_ConsumerTwo",
       "type": "object"
     },
@@ -237,7 +225,6 @@
           "type": "boolean"
         },
         "name": {
-          "default": null,
           "description": "Port name",
           "title": "Name",
           "type": "string"
@@ -255,6 +242,9 @@
           "type": "string"
         }
       },
+      "required": [
+        "name"
+      ],
       "title": "object_module_RefObject",
       "type": "object"
     }

--- a/tests/samples/schemas/objects.ibek.ioc.schema.json
+++ b/tests/samples/schemas/objects.ibek.ioc.schema.json
@@ -38,17 +38,19 @@
           "type": "boolean"
         },
         "name": {
-          "default": null,
           "description": "Consumer name",
           "title": "Name",
           "type": "string"
         },
         "PORT": {
-          "default": null,
           "description": "a reference to an RefObject",
           "title": "Port"
         }
       },
+      "required": [
+        "name",
+        "PORT"
+      ],
       "title": "object_module_Consumer",
       "type": "object"
     },
@@ -68,17 +70,19 @@
           "type": "boolean"
         },
         "name": {
-          "default": null,
           "description": "Consumer name",
           "title": "Name",
           "type": "string"
         },
         "PORT": {
-          "default": null,
           "description": "a reference to an RefObject",
           "title": "Port"
         }
       },
+      "required": [
+        "name",
+        "PORT"
+      ],
       "title": "object_module_ConsumerTwo",
       "type": "object"
     },
@@ -98,7 +102,6 @@
           "type": "boolean"
         },
         "name": {
-          "default": null,
           "description": "Port name",
           "title": "Name",
           "type": "string"
@@ -116,6 +119,9 @@
           "type": "string"
         }
       },
+      "required": [
+        "name"
+      ],
       "title": "object_module_RefObject",
       "type": "object"
     }

--- a/tests/samples/yaml/all.ibek.ioc.yaml
+++ b/tests/samples/yaml/all.ibek.ioc.yaml
@@ -9,18 +9,20 @@ entities:
     name: Ref1
 
   - type: module.AllObject
-    name: A Consumer
+    name: AllObject One
     my_object: Ref1
     my_int_enum: full_speed
     my_inferred_enum: third
     clock_rate: dummy
+    my_str: AllObject One String
 
   - type: module.AllObject
-    name: Another Consumer
+    name: AllObject Two
     my_object: Ref1
     my_int_enum: all_ahead
     my_inferred_enum: first
     clock_rate: 2Hz
+    my_str: AllObject Two String
 
   - type: object_module.ConsumerTwo
     name: Disabled Consumer

--- a/tests/samples/yaml/all.ibek.support.yaml
+++ b/tests/samples/yaml/all.ibek.support.yaml
@@ -25,14 +25,6 @@ defs:
           stop: 0
 
       - type: enum
-        name: my_mixed_enum
-        description: mixed enumerated type
-        values:
-          first: start
-          second: stop
-          third: 3.0
-
-      - type: enum
         name: my_inferred_enum
         description: integer enumerated type with inferred value
         values:
@@ -52,6 +44,8 @@ defs:
           10Hz: 3
           dummy:
 
+      # string demonstrates the use of no default to force user to specify
+      # values in the IOC YAML
       - type: str
         name: my_str
         description: string arg
@@ -86,12 +80,15 @@ defs:
         name: testPreInit
         args:
           identifier: "{{ name }}"
-          TestValue: test_value:{{ test_value }}
+          TestValue: "'{{ my_str }}'"
 
       - type: text
         value: |
-          The value of my_inferred_enum is {{ my_inferred_enum }}
-          The value of clock_rate is {{ clock_rate }}
+          my_str =                    {{ my_str }}
+          my_inferred_enum =          {{ my_inferred_enum }}
+          clock_rate =                {{ clock_rate }}
+          my_mixed_enum_no_default =  {{ my_mixed_enum_no_default }}
+          .
 
     post_init:
       - type: function

--- a/tests/samples/yaml/bad_default.ibek.ioc.yaml
+++ b/tests/samples/yaml/bad_default.ibek.ioc.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../schemas/objects.ibek.ioc.schema.json
+
+ioc_name: test-bad-defaults-ioc
+description: a basic example for testing multiple support definitions
+generic_ioc_image: ghcr.io/epics-containers/ioc-template:23.3.2
+
+entities:
+  # deliberately do not specify name to test failure case for no default
+  # my_str: AllObject One String
+  - type: object_module.RefObject

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -52,3 +52,19 @@ def test_loading_module_twice(tmp_path: Path, samples: Path):
         generic_ioc2(**instance)
 
     assert "Duplicate id" in str(ctx.value)
+
+
+def test_defaults(tmp_path: Path, samples: Path):
+    """
+    Check you cannot redefine a counter with the same name and different params
+    """
+
+    clear_entity_model_ids()
+    entity_file = samples / "yaml" / "bad_default.ibek.ioc.yaml"
+    definition_file1 = samples / "yaml" / "objects.ibek.support.yaml"
+
+    with pytest.raises(ValueError) as ctx:
+        run_cli("build-startup", entity_file, definition_file1)
+
+    assert "Field required [type=missing" in str(ctx.value)
+    assert "entities.0.`object_module.RefObject`.name" in str(ctx.value)


### PR DESCRIPTION
This fixes an issue where Args with no specified default were being allowed to not be supplied in the IOC schema. It should be a schema error if you supply no value in the IOC and the SUPPORT does not supply a default.

@coretl FYI

My mistake was removing default from the Support Arg types.
We do need default = None in the Support YAML so that IOCs can decide to specify defaults for Args.

But when we translate that into an IOC class we need to set default = PydanticUndefined where the instance of the Arg has default = None.