### PR TITLE
make support schema artifact

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -119,6 +119,9 @@ jobs:
       HAS_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN != '' }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - uses: actions/download-artifact@v3
 
       - name: Fixup blank lockfiles
@@ -138,6 +141,7 @@ jobs:
             lockfiles/*
             tests/samples/schemas/ibek.support.schema.json
           generate_release_notes: true
+
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Publishes the support schema at 
https://github.com/epics-containers/ibek/releases/download/0.11.2/ibek.support.schema.json
 