### PR TITLE
builder2ibek.support fixes for tetramm

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,5 +19,5 @@ repos:
         name: Run ruff
         stages: [commit]
         language: system
-        entry: ruff
+        entry: ruff check
         types: [python]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,8 @@
             "program": "builder2ibek.support.py",
             "console": "integratedTerminal",
             "args": [
-                "/dls_sw/prod/R3.14.12.7/support/devIocStats/3-1-14dls3-3"
+                "/dls_sw/prod/R3.14.12.7/support/quadEM/9-4dls1",
+                "../quadEM.ibek.support.yaml"
             ],
             "justMyCode": false
         },

--- a/builder2ibek.README.md
+++ b/builder2ibek.README.md
@@ -28,6 +28,12 @@ recent version of the pmac module:
 ./builder2ibek.support.py /dls_sw/prod/R3.14.12.7/support/pmac/2-5-23beta1/ -o '14:A+B 474:A+B 801:1 805:1.0 804:1.0'
 ```
 
+And this for the tetramm:
+```bash
+./builder2ibek.support.py /dls_sw/prod/R3.14.12.7/support/quadEM/9-4dls1  ../quadEM.ibek.support.yaml  -o'21:2 25:100'
+```
+
+
 Without the 3 overrides the tools will fail as builder.py tries to convert
 these 3 args to int.
 

--- a/builder2ibek.support.py
+++ b/builder2ibek.support.py
@@ -291,7 +291,7 @@ class Builder2Support:
         # Classes with a leading underscore are assumed to be private / abstract
         # builder never exposes them to xeb so we don't want them in the YAML
         if builder_class.__name__.split(".")[-1].startswith("_"):
-            print "SKIPPING private class %s" % builder_class.__name__
+            print("SKIPPING private class %s" % builder_class.__name__)
             return None, None
 
         arg_info = ArgInfo(
@@ -360,8 +360,8 @@ class Builder2Support:
                 # are brought in by instantiating their parent so do not need to
                 # appear in the support yaml
                 print(
-                    "TODO:- No substitutions for %s " % template +
-                    "- this should be included by the above template"
+                    "TODO:- No substitutions for %s " % template
+                    + "- this should be included by the above template"
                 )
 
         if len(databases) > 0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ commands =
 
 [tool.ruff]
 src = ["src", "tests"]
-ignore = [
+lint.ignore = [
     "C408", # Unnecessary collection call - e.g. list(...) instead of [...]
     "E501", # Line too long, should be fixed by black.
 ]
@@ -122,7 +122,7 @@ select = [
     "W",    # pycodestyle warnings - https://beta.ruff.rs/docs/rules/#warning-w
     "I001", # isort
 ]
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "builder2ibek.support.py" = ["E402"]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Add some changes to make the tetramm support module work with builder2ibek.support
- recognize that templates in 'all_templates' may be ones that are included by msi directives in other templates. These appear with no substitution list. Skip them and print a message.
- treat classes in builder.py with leading underscore as abstract or private and do not try to instantiate them or include them in the support yaml. This is consistent with how builder treats these.

For the tetram there are template subsitutions generated by XML with no indication of the type. The following command overrides a couple of fields that are supposed to be integers:
```bash
./builder2ibek.support.py /dls_sw/prod/R3.14.12.7/support/quadEM/9-4dls1  ../quadEM.ibek.support.yaml  -o'21:2 25:100'
```

@JamesOHeaDLS if you try out the above command it should generate you some yaml. Note that the yaml will need a look over manually and there are a couple of TODOs marked in it where the code could not find some of the macros.
I also note that there are some empty 'database' sections which may just need deleting.

You may find it instructive to try without the -o substitutions - you will see that the errors you get make it reasonably clear what sort of overrides are needed.

You should treat this yaml as a first pass to get you started . This tool will never be able to do the full job for any complexity of builder.py. On the other hand the goal for the builder xml -> ioc.yaml is to be perfect and that is the one that will get run many times for every instance of an IOC (it is also fully customizable on a per support module basis).