### PR TITLE
Add collections

### DIFF
--- a/src/ibek/args.py
+++ b/src/ibek/args.py
@@ -1,0 +1,87 @@
+"""
+Define classes to specify arguments to Definitions
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from pydantic import Field
+from typing_extensions import Literal
+
+from .globals import BaseSettings
+
+
+class Value(BaseSettings):
+    """A calculated string value for a definition"""
+
+    name: str = Field(description="Name of the value that the IOC instance will expose")
+    description: str = Field(
+        description="Description of what the value will be used for"
+    )
+    value: str = Field(description="The contents of the value")
+
+
+class Arg(BaseSettings):
+    """Base class for all Argument Types"""
+
+    type: str
+    name: str = Field(
+        description="Name of the argument that the IOC instance should pass"
+    )
+    description: str = Field(
+        description="Description of what the argument will be used for"
+    )
+
+
+class FloatArg(Arg):
+    """An argument with a float value"""
+
+    type: Literal["float"] = "float"
+    default: Optional[float] = None
+
+
+class StrArg(Arg):
+    """An argument with a str value"""
+
+    type: Literal["str"] = "str"
+    default: Optional[str] = None
+
+
+class IntArg(Arg):
+    """An argument with an int value"""
+
+    type: Literal["int"] = "int"
+    default: Optional[int] = None
+
+
+class BoolArg(Arg):
+    """An argument with an bool value"""
+
+    type: Literal["bool"] = "bool"
+    default: Optional[bool] = None
+
+
+class ObjectArg(Arg):
+    """A reference to another entity defined in this IOC"""
+
+    type: Literal["object"] = "object"
+    default: Optional[str] = None
+
+
+class IdArg(Arg):
+    """Explicit ID argument that an object can refer to"""
+
+    type: Literal["id"] = "id"
+    default: Optional[str] = None
+
+
+class EnumArg(Arg):
+    """An argument with an enum value"""
+
+    type: Literal["enum"] = "enum"
+    default: Optional[Any] = None
+
+    values: Dict[str, Any] = Field(
+        description="provides a list of values to make this argument an Enum",
+    )

--- a/src/ibek/args.py
+++ b/src/ibek/args.py
@@ -1,5 +1,5 @@
 """
-Define classes to specify arguments to Definitions
+Classes to specify arguments to Definitions
 """
 
 from __future__ import annotations

--- a/src/ibek/collection.py
+++ b/src/ibek/collection.py
@@ -1,5 +1,5 @@
 """
-The Support Class represents a deserialized <MODULE_NAME>.ibek.support.yaml file.
+Define a collection of entities with arguments for instantiating them
 """
 
 from __future__ import annotations

--- a/src/ibek/collection.py
+++ b/src/ibek/collection.py
@@ -1,0 +1,32 @@
+"""
+The Support Class represents a deserialized <MODULE_NAME>.ibek.support.yaml file.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from pydantic import Field
+
+from .args import Arg, Value
+from .ioc import Entity
+
+
+class CollectionDefinition:
+    name: str = Field(
+        description="Publish Definition as type <module>.<name> for IOC instances"
+    )
+    description: str = Field(
+        description="A description of the Support module defined here"
+    )
+    # declare Arg as Union of its subclasses for Pydantic to be able to deserialize
+    args: Sequence[Union[tuple(Arg.__subclasses__())]] = Field(  # type: ignore
+        description="The arguments IOC instance should supply", default=()
+    )
+    values: Sequence[Value] = Field(
+        description="Calculated values to use as additional arguments", default=()
+    )
+
+    entities: Sequence[Entity] = Field(
+        description="The entities that this collection is to instantiate", default=()
+    )

--- a/src/ibek/collection.py
+++ b/src/ibek/collection.py
@@ -9,10 +9,11 @@ from typing import Sequence, Union
 from pydantic import Field
 
 from .args import Arg, Value
+from .globals import BaseSettings
 from .ioc import Entity
 
 
-class CollectionDefinition:
+class CollectionDefinition(BaseSettings):
     name: str = Field(
         description="Publish Definition as type <module>.<name> for IOC instances"
     )

--- a/src/ibek/definition.py
+++ b/src/ibek/definition.py
@@ -1,0 +1,154 @@
+"""
+The Definition class describes what a given support module can instantiate.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Mapping, Optional, Sequence, Union
+
+from pydantic import Field, PydanticUndefinedAnnotation
+from typing_extensions import Literal
+
+from .args import Arg, IdArg, Value
+from .globals import BaseSettings
+
+
+def default(T: type):
+    """
+    defines a default type which may be
+    """
+    return Field(
+        Union[Optional[T], PydanticUndefinedAnnotation],
+        description="If given, instance doesn't supply argument, what value should be used",
+    )
+
+
+class When(Enum):
+    first = "first"
+    every = "every"
+    last = "last"
+
+
+class Database(BaseSettings):
+    """
+    A database file that should be loaded by the startup script and its args
+    """
+
+    file: str = Field(
+        description="Filename of the database template in <module_root>/db"
+    )
+
+    enabled: str = Field(
+        description="Set to False to disable loading this database", default="True"
+    )
+
+    args: Mapping[str, Optional[str]] = Field(
+        description=(
+            "Dictionary of args and values to pass through to database. "
+            "A value of None is equivalent to ARG: '{{ ARG }}'. "
+            "See `UTILS.render_map` for more details."
+        )
+    )
+
+
+class EnvironmentVariable(BaseSettings):
+    """
+    An environment variable that should be set in the startup script
+    """
+
+    name: str = Field(description="Name of environment variable")
+    value: str = Field(description="Value to set")
+
+
+class Comment(BaseSettings):
+    """
+    A script snippet that will have '# ' prepended to every line
+    for insertion into the startup script
+    """
+
+    type: Literal["comment"] = "comment"
+    when: When = Field(description="One of first / every / last", default="every")
+    value: str = Field(
+        description="A comment to add into the startup script", default=""
+    )
+
+
+class Text(BaseSettings):
+    """
+    A script snippet to insert into the startup script
+    """
+
+    type: Literal["text"] = "text"
+    when: str = Field(description="One of first / every / last", default="every")
+    value: str = Field(description="raw text to add to the startup script", default="")
+
+
+Script = Sequence[Union[Text, Comment]]
+
+
+class EntityPVI(BaseSettings):
+    """Entity PVI definition"""
+
+    yaml_path: str = Field(
+        description="Path to .pvi.device.yaml - absolute or relative to PVI_DEFS"
+    )
+    ui_index: bool = Field(
+        True,
+        description="Whether to add the UI to the IOC index.",
+    )
+    ui_macros: dict[str, str | None] = Field(
+        None,
+        description=(
+            "Macros to launch the UI on the IOC index. "
+            "These must be args of the Entity this is attached to."
+        ),
+    )
+    pv: bool = Field(
+        False,
+        description=(
+            "Whether to generate a PVI PV. This adds a database template with info "
+            "tags that create a PVAccess PV representing the device structure."
+        ),
+    )
+    pv_prefix: str = Field("", description='PV prefix for PVI PV - e.g. "$(P)"')
+
+
+class Definition(BaseSettings):
+    """
+    A single definition of a class of Entity that an IOC instance may instantiate
+    """
+
+    name: str = Field(
+        description="Publish Definition as type <module>.<name> for IOC instances"
+    )
+    description: str = Field(
+        description="A description of the Support module defined here"
+    )
+    # declare Arg as Union of its subclasses for Pydantic to be able to deserialize
+    args: Sequence[Union[tuple(Arg.__subclasses__())]] = Field(  # type: ignore
+        description="The arguments IOC instance should supply", default=()
+    )
+    values: Sequence[Value] = Field(
+        description="Calculated values to use as additional arguments", default=()
+    )
+    databases: Sequence[Database] = Field(
+        description="Databases to instantiate", default=[]
+    )
+    pre_init: Script = Field(
+        description="Startup script snippets to add before iocInit()", default=()
+    )
+    post_init: Script = Field(
+        description="Startup script snippets to add post iocInit(), such as dbpf",
+        default=(),
+    )
+    env_vars: Sequence[EnvironmentVariable] = Field(
+        description="Environment variables to set in the boot script", default=()
+    )
+    pvi: EntityPVI = Field(description="PVI definition for Entity", default=None)
+
+    def _get_id_arg(self):
+        """Returns the name of the ID argument for this definition, if it exists"""
+        for arg in self.args:
+            if isinstance(arg, IdArg):
+                return arg.name

--- a/src/ibek/entity_model.py
+++ b/src/ibek/entity_model.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import builtins
+from typing import Annotated, Any, Dict, Literal, Sequence, Tuple, Type, Union
+
+from pydantic import Field, create_model, field_validator
+from pydantic.fields import FieldInfo
+from pydantic_core import PydanticUndefined
+
+from .args import EnumArg, IdArg, ObjectArg
+from .ioc import IOC, Entity, EnumVal, id_to_entity
+from .support import Definition, Support
+
+
+def make_entity_model(definition: Definition, support: Support) -> Type[Entity]:
+    """
+    Create an Entity Model from a Definition instance and a Support instance.
+    """
+
+    def add_arg(name, typ, description, default):
+        if default is None:
+            default = PydanticUndefined
+        args[name] = (
+            typ,
+            FieldInfo(description=description, default=default),
+        )
+
+    args: Dict[str, Tuple[type, Any]] = {}
+    validators: Dict[str, Any] = {}
+
+    # fully qualified name of the Entity class including support module
+    full_name = f"{support.module}.{definition.name}"
+
+    # add in each of the arguments as a Field in the Entity
+    for arg in definition.args:
+        full_arg_name = f"{full_name}.{arg.name}"
+        arg_type: Any
+
+        if isinstance(arg, ObjectArg):
+
+            @field_validator(arg.name, mode="after")
+            def lookup_instance(cls, id):
+                try:
+                    return id_to_entity[id]
+                except KeyError:
+                    raise ValueError(f"object {id} not found in {list(id_to_entity)}")
+
+            validators[full_arg_name] = lookup_instance
+            arg_type = object
+
+        elif isinstance(arg, IdArg):
+            arg_type = str
+
+        elif isinstance(arg, EnumArg):
+            # Pydantic uses the values of the Enum as the options in the schema.
+            # Here we arrange for the keys to be in the schema (what a user supplies)
+            # but the values to be what is rendered when jinja refers to the enum
+            enum_swapped = {}
+            for k, v in arg.values.items():
+                enum_swapped[str(v) if v else str(k)] = k
+            val_enum = EnumVal(arg.name, enum_swapped)  # type: ignore
+            arg_type = val_enum
+
+        else:
+            # arg.type is str, int, float, etc.
+            arg_type = getattr(builtins, arg.type)
+        default = getattr(arg, "default", None)
+        add_arg(arg.name, arg_type, arg.description, default)
+
+    # add in the calculated values Jinja Templates as Fields in the Entity
+    for value in definition.values:
+        add_arg(value.name, str, value.description, value.value)
+
+    # add the type literal which discriminates between the different Entity classes
+    typ = Literal[full_name]  # type: ignore
+    add_arg("type", typ, definition.description, full_name)
+
+    entity_cls = create_model(
+        full_name.replace(".", "_"),
+        **args,
+        __validators__=validators,
+        __base__=Entity,
+    )  # type: ignore
+
+    # add a link back to the Definition Instance that generated this Entity Class
+    entity_cls.__definition__ = definition
+
+    return entity_cls
+
+
+def make_entity_models(support: Support):
+    """
+    Create Entity subclasses for all Definition instances in the given
+    Support instance. Returns a list of the Entity subclasses Models.
+    """
+
+    entity_models = []
+    entity_names = []
+
+    for definition in support.defs:
+        entity_models.append(make_entity_model(definition, support))
+        if definition.name in entity_names:
+            # not tested because schema validation will always catch this first
+            raise ValueError(f"Duplicate entity name {definition.name}")
+        entity_names.append(definition.name)
+
+    return entity_models
+
+
+def make_ioc_model(entity_models: Sequence[Type[Entity]]) -> Type[IOC]:
+    """
+    Create an IOC derived model, by setting its entities attribute to
+    be of type 'list of Entity derived classes'.
+    """
+
+    entity_union = Union[tuple(entity_models)]  # type: ignore
+    discriminated = Annotated[entity_union, Field(discriminator="type")]  # type: ignore
+
+    class NewIOC(IOC):
+        entities: Sequence[discriminated] = Field(
+            description="List of entities this IOC instantiates"
+        )
+
+    return NewIOC

--- a/src/ibek/entity_model.py
+++ b/src/ibek/entity_model.py
@@ -11,6 +11,8 @@ from pydantic import Field, create_model, field_validator
 from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined
 
+from ibek.collection import CollectionDefinition
+
 from .args import EnumArg, IdArg, ObjectArg
 from .ioc import IOC, Entity, EnumVal, id_to_entity
 from .support import Definition, Support
@@ -102,7 +104,11 @@ def make_entity_models(support: Support):
     entity_names = []
 
     for definition in support.defs:
-        entity_models.append(make_entity_model(definition, support))
+        if isinstance(definition, Definition):
+            entity_models.append(make_entity_model(definition, support))
+        elif isinstance(definition, CollectionDefinition):
+            """TODO: do we need to do anything here?"""
+
         if definition.name in entity_names:
             # not tested because schema validation will always catch this first
             raise ValueError(f"Duplicate entity name {definition.name}")

--- a/src/ibek/entity_model.py
+++ b/src/ibek/entity_model.py
@@ -1,3 +1,7 @@
+"""
+functions for making Entity models
+"""
+
 from __future__ import annotations
 
 import builtins

--- a/src/ibek/gen_scripts.py
+++ b/src/ibek/gen_scripts.py
@@ -12,12 +12,13 @@ from ruamel.yaml.main import YAML
 
 from ibek.utils import UTILS
 
+from .definition import Database
 from .entity_model import make_entity_models, make_ioc_model
 from .globals import TEMPLATES
 from .ioc import IOC, Entity, clear_entity_model_ids
 from .render import Render
 from .render_db import RenderDb
-from .support import Database, Support
+from .support import Support
 
 log = logging.getLogger(__name__)
 

--- a/src/ibek/gen_scripts.py
+++ b/src/ibek/gen_scripts.py
@@ -12,8 +12,9 @@ from ruamel.yaml.main import YAML
 
 from ibek.utils import UTILS
 
+from .entity_model import make_entity_models, make_ioc_model
 from .globals import TEMPLATES
-from .ioc import IOC, Entity, clear_entity_model_ids, make_entity_models, make_ioc_model
+from .ioc import IOC, Entity, clear_entity_model_ids
 from .render import Render
 from .render_db import RenderDb
 from .support import Database, Support

--- a/src/ibek/ioc.py
+++ b/src/ibek/ioc.py
@@ -1,5 +1,5 @@
 """
-Functions for generating an IocInstance derived class from a
+Classes for generating an IocInstance derived class from a
 support module definition YAML file
 """
 

--- a/src/ibek/ioc.py
+++ b/src/ibek/ioc.py
@@ -18,8 +18,9 @@ from pydantic import (
 from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined
 
+from .args import EnumArg, IdArg, ObjectArg
 from .globals import BaseSettings
-from .support import Definition, EnumArg, IdArg, ObjectArg, Support
+from .support import Definition, Support
 from .utils import UTILS
 
 id_to_entity: Dict[str, Entity] = {}

--- a/src/ibek/ioc.py
+++ b/src/ibek/ioc.py
@@ -5,25 +5,26 @@ support module definition YAML file
 
 from __future__ import annotations
 
-import builtins
 from enum import Enum
-from typing import Annotated, Any, Dict, Literal, Sequence, Tuple, Type, Union
+from typing import Dict, Sequence
 
 from pydantic import (
     Field,
-    create_model,
-    field_validator,
     model_validator,
 )
-from pydantic.fields import FieldInfo
-from pydantic_core import PydanticUndefined
 
-from .args import EnumArg, IdArg, ObjectArg
+from .args import IdArg
 from .globals import BaseSettings
-from .support import Definition, Support
+from .support import Definition
 from .utils import UTILS
 
 id_to_entity: Dict[str, Entity] = {}
+
+
+def clear_entity_model_ids():
+    """Resets the global id_to_entity dict. Used for testing."""
+
+    id_to_entity.clear()
 
 
 class EnumVal(Enum):
@@ -73,124 +74,6 @@ class Entity(BaseSettings):
         # if this entity has an id then its string representation is the value of id
         id_name = self.__definition__._get_id_arg()
         return getattr(self, id_name) if id_name else super().__str__()
-
-
-def make_entity_model(definition: Definition, support: Support) -> Type[Entity]:
-    """
-    Create an Entity Model from a Definition instance and a Support instance.
-    """
-
-    def add_arg(name, typ, description, default):
-        if default is None:
-            default = PydanticUndefined
-        args[name] = (
-            typ,
-            FieldInfo(description=description, default=default),
-        )
-
-    args: Dict[str, Tuple[type, Any]] = {}
-    validators: Dict[str, Any] = {}
-
-    # fully qualified name of the Entity class including support module
-    full_name = f"{support.module}.{definition.name}"
-
-    # add in each of the arguments as a Field in the Entity
-    for arg in definition.args:
-        full_arg_name = f"{full_name}.{arg.name}"
-        arg_type: Any
-
-        if isinstance(arg, ObjectArg):
-
-            @field_validator(arg.name, mode="after")
-            def lookup_instance(cls, id):
-                try:
-                    return id_to_entity[id]
-                except KeyError:
-                    raise ValueError(f"object {id} not found in {list(id_to_entity)}")
-
-            validators[full_arg_name] = lookup_instance
-            arg_type = object
-
-        elif isinstance(arg, IdArg):
-            arg_type = str
-
-        elif isinstance(arg, EnumArg):
-            # Pydantic uses the values of the Enum as the options in the schema.
-            # Here we arrange for the keys to be in the schema (what a user supplies)
-            # but the values to be what is rendered when jinja refers to the enum
-            enum_swapped = {}
-            for k, v in arg.values.items():
-                enum_swapped[str(v) if v else str(k)] = k
-            val_enum = EnumVal(arg.name, enum_swapped)  # type: ignore
-            arg_type = val_enum
-
-        else:
-            # arg.type is str, int, float, etc.
-            arg_type = getattr(builtins, arg.type)
-        default = getattr(arg, "default", None)
-        add_arg(arg.name, arg_type, arg.description, default)
-
-    # add in the calculated values Jinja Templates as Fields in the Entity
-    for value in definition.values:
-        add_arg(value.name, str, value.description, value.value)
-
-    # add the type literal which discriminates between the different Entity classes
-    typ = Literal[full_name]  # type: ignore
-    add_arg("type", typ, definition.description, full_name)
-
-    entity_cls = create_model(
-        full_name.replace(".", "_"),
-        **args,
-        __validators__=validators,
-        __base__=Entity,
-    )  # type: ignore
-
-    # add a link back to the Definition Instance that generated this Entity Class
-    entity_cls.__definition__ = definition
-
-    return entity_cls
-
-
-def make_entity_models(support: Support):
-    """
-    Create Entity subclasses for all Definition instances in the given
-    Support instance. Returns a list of the Entity subclasses Models.
-    """
-
-    entity_models = []
-    entity_names = []
-
-    for definition in support.defs:
-        entity_models.append(make_entity_model(definition, support))
-        if definition.name in entity_names:
-            # not tested because schema validation will always catch this first
-            raise ValueError(f"Duplicate entity name {definition.name}")
-        entity_names.append(definition.name)
-
-    return entity_models
-
-
-def make_ioc_model(entity_models: Sequence[Type[Entity]]) -> Type[IOC]:
-    """
-    Create an IOC derived model, by setting its entities attribute to
-    be of type 'list of Entity derived classes'.
-    """
-
-    entity_union = Union[tuple(entity_models)]  # type: ignore
-    discriminated = Annotated[entity_union, Field(discriminator="type")]  # type: ignore
-
-    class NewIOC(IOC):
-        entities: Sequence[discriminated] = Field(
-            description="List of entities this IOC instantiates"
-        )
-
-    return NewIOC
-
-
-def clear_entity_model_ids():
-    """Resets the global id_to_entity dict."""
-
-    id_to_entity.clear()
 
 
 class IOC(BaseSettings):

--- a/src/ibek/ioc.py
+++ b/src/ibek/ioc.py
@@ -14,8 +14,8 @@ from pydantic import (
 )
 
 from .args import IdArg
+from .definition import Definition
 from .globals import BaseSettings
-from .support import Definition
 from .utils import UTILS
 
 id_to_entity: Dict[str, Entity] = {}

--- a/src/ibek/render.py
+++ b/src/ibek/render.py
@@ -4,8 +4,8 @@ Functions for rendering lines in the boot script using Jinja2
 
 from typing import Callable, List, Optional, Union
 
+from .definition import Comment, Script, Text, When
 from .ioc import IOC, Entity
-from .support import Comment, Script, Text, When
 from .utils import UTILS
 
 

--- a/src/ibek/render_db.py
+++ b/src/ibek/render_db.py
@@ -6,8 +6,8 @@ support module definitions
 from dataclasses import dataclass
 from typing import Any, Dict, List, Mapping, Optional, Tuple
 
+from ibek.definition import Database
 from ibek.ioc import IOC, Entity
-from ibek.support import Database
 from ibek.utils import UTILS
 
 

--- a/src/ibek/runtime_cmds/commands.py
+++ b/src/ibek/runtime_cmds/commands.py
@@ -8,10 +8,10 @@ from pvi._format.dls import DLSFormatter
 from pvi._format.template import format_template
 from pvi.device import Device
 
+from ibek.definition import Database
 from ibek.gen_scripts import create_boot_script, create_db_script, ioc_deserialize
 from ibek.globals import GLOBALS, NaturalOrderGroup
 from ibek.ioc import IOC, Entity
-from ibek.support import Database
 from ibek.utils import UTILS
 
 runtime_cli = typer.Typer(cls=NaturalOrderGroup)

--- a/src/ibek/support.py
+++ b/src/ibek/support.py
@@ -9,6 +9,7 @@ from typing import Sequence
 
 from pydantic import Field
 
+from .collection import CollectionDefinition
 from .definition import Definition
 from .globals import BaseSettings
 
@@ -21,7 +22,7 @@ class Support(BaseSettings):
     """
 
     module: str = Field(description="Support module name, normally the repo name")
-    defs: Sequence[Definition] = Field(
+    defs: Sequence[Definition | CollectionDefinition] = Field(
         description="The definitions an IOC can create using this module"
     )
 

--- a/src/ibek/support.py
+++ b/src/ibek/support.py
@@ -6,11 +6,12 @@ from __future__ import annotations
 
 import json
 from enum import Enum
-from typing import Any, Dict, Mapping, Optional, Sequence, Union
+from typing import Mapping, Optional, Sequence, Union
 
 from pydantic import Field, PydanticUndefinedAnnotation
 from typing_extensions import Literal
 
+from .args import Arg, IdArg, Value
 from .globals import BaseSettings
 
 
@@ -28,71 +29,6 @@ class When(Enum):
     first = "first"
     every = "every"
     last = "last"
-
-
-class Arg(BaseSettings):
-    """Base class for all Argument Types"""
-
-    type: str
-    name: str = Field(
-        description="Name of the argument that the IOC instance should pass"
-    )
-    description: str = Field(
-        description="Description of what the argument will be used for"
-    )
-
-
-class FloatArg(Arg):
-    """An argument with a float value"""
-
-    type: Literal["float"] = "float"
-    default: Optional[float] = None
-
-
-class StrArg(Arg):
-    """An argument with a str value"""
-
-    type: Literal["str"] = "str"
-    default: Optional[str] = None
-
-
-class IntArg(Arg):
-    """An argument with an int value"""
-
-    type: Literal["int"] = "int"
-    default: Optional[int] = None
-
-
-class BoolArg(Arg):
-    """An argument with an bool value"""
-
-    type: Literal["bool"] = "bool"
-    default: Optional[bool] = None
-
-
-class ObjectArg(Arg):
-    """A reference to another entity defined in this IOC"""
-
-    type: Literal["object"] = "object"
-    default: Optional[str] = None
-
-
-class IdArg(Arg):
-    """Explicit ID argument that an object can refer to"""
-
-    type: Literal["id"] = "id"
-    default: Optional[str] = None
-
-
-class EnumArg(Arg):
-    """An argument with an enum value"""
-
-    type: Literal["enum"] = "enum"
-    default: Optional[Any] = None
-
-    values: Dict[str, Any] = Field(
-        description="provides a list of values to make this argument an Enum",
-    )
 
 
 class Database(BaseSettings):
@@ -149,16 +85,6 @@ class Text(BaseSettings):
     value: str = Field(description="raw text to add to the startup script", default="")
 
 
-class Value(BaseSettings):
-    """A calculated string value for a definition"""
-
-    name: str = Field(description="Name of the value that the IOC instance will expose")
-    description: str = Field(
-        description="Description of what the value will be used for"
-    )
-    value: str = Field(description="The contents of the value")
-
-
 Script = Sequence[Union[Text, Comment]]
 
 
@@ -205,7 +131,7 @@ class Definition(BaseSettings):
         description="The arguments IOC instance should supply", default=()
     )
     values: Sequence[Value] = Field(
-        description="The values IOC instance should supply", default=()
+        description="Calculated values to use as additional arguments", default=()
     )
     databases: Sequence[Database] = Field(
         description="Databases to instantiate", default=[]

--- a/src/ibek/support.py
+++ b/src/ibek/support.py
@@ -1,158 +1,16 @@
 """
-The Support Class represents a deserialized <MODULE_NAME>.ibek.support.yaml file.
+Support Class to represent a deserialized <MODULE_NAME>.ibek.support.yaml file.
 """
 
 from __future__ import annotations
 
 import json
-from enum import Enum
-from typing import Mapping, Optional, Sequence, Union
+from typing import Sequence
 
-from pydantic import Field, PydanticUndefinedAnnotation
-from typing_extensions import Literal
+from pydantic import Field
 
-from .args import Arg, IdArg, Value
+from .definition import Definition
 from .globals import BaseSettings
-
-
-def default(T: type):
-    """
-    defines a default type which may be
-    """
-    return Field(
-        Union[Optional[T], PydanticUndefinedAnnotation],
-        description="If given, instance doesn't supply argument, what value should be used",
-    )
-
-
-class When(Enum):
-    first = "first"
-    every = "every"
-    last = "last"
-
-
-class Database(BaseSettings):
-    """
-    A database file that should be loaded by the startup script and its args
-    """
-
-    file: str = Field(
-        description="Filename of the database template in <module_root>/db"
-    )
-
-    enabled: str = Field(
-        description="Set to False to disable loading this database", default="True"
-    )
-
-    args: Mapping[str, Optional[str]] = Field(
-        description=(
-            "Dictionary of args and values to pass through to database. "
-            "A value of None is equivalent to ARG: '{{ ARG }}'. "
-            "See `UTILS.render_map` for more details."
-        )
-    )
-
-
-class EnvironmentVariable(BaseSettings):
-    """
-    An environment variable that should be set in the startup script
-    """
-
-    name: str = Field(description="Name of environment variable")
-    value: str = Field(description="Value to set")
-
-
-class Comment(BaseSettings):
-    """
-    A script snippet that will have '# ' prepended to every line
-    for insertion into the startup script
-    """
-
-    type: Literal["comment"] = "comment"
-    when: When = Field(description="One of first / every / last", default="every")
-    value: str = Field(
-        description="A comment to add into the startup script", default=""
-    )
-
-
-class Text(BaseSettings):
-    """
-    A script snippet to insert into the startup script
-    """
-
-    type: Literal["text"] = "text"
-    when: str = Field(description="One of first / every / last", default="every")
-    value: str = Field(description="raw text to add to the startup script", default="")
-
-
-Script = Sequence[Union[Text, Comment]]
-
-
-class EntityPVI(BaseSettings):
-    """Entity PVI definition"""
-
-    yaml_path: str = Field(
-        description="Path to .pvi.device.yaml - absolute or relative to PVI_DEFS"
-    )
-    ui_index: bool = Field(
-        True,
-        description="Whether to add the UI to the IOC index.",
-    )
-    ui_macros: dict[str, str | None] = Field(
-        None,
-        description=(
-            "Macros to launch the UI on the IOC index. "
-            "These must be args of the Entity this is attached to."
-        ),
-    )
-    pv: bool = Field(
-        False,
-        description=(
-            "Whether to generate a PVI PV. This adds a database template with info "
-            "tags that create a PVAccess PV representing the device structure."
-        ),
-    )
-    pv_prefix: str = Field("", description='PV prefix for PVI PV - e.g. "$(P)"')
-
-
-class Definition(BaseSettings):
-    """
-    A single definition of a class of Entity that an IOC instance may instantiate
-    """
-
-    name: str = Field(
-        description="Publish Definition as type <module>.<name> for IOC instances"
-    )
-    description: str = Field(
-        description="A description of the Support module defined here"
-    )
-    # declare Arg as Union of its subclasses for Pydantic to be able to deserialize
-    args: Sequence[Union[tuple(Arg.__subclasses__())]] = Field(  # type: ignore
-        description="The arguments IOC instance should supply", default=()
-    )
-    values: Sequence[Value] = Field(
-        description="Calculated values to use as additional arguments", default=()
-    )
-    databases: Sequence[Database] = Field(
-        description="Databases to instantiate", default=[]
-    )
-    pre_init: Script = Field(
-        description="Startup script snippets to add before iocInit()", default=()
-    )
-    post_init: Script = Field(
-        description="Startup script snippets to add post iocInit(), such as dbpf",
-        default=(),
-    )
-    env_vars: Sequence[EnvironmentVariable] = Field(
-        description="Environment variables to set in the boot script", default=()
-    )
-    pvi: EntityPVI = Field(description="PVI definition for Entity", default=None)
-
-    def _get_id_arg(self):
-        """Returns the name of the ID argument for this definition, if it exists"""
-        for arg in self.args:
-            if isinstance(arg, IdArg):
-                return arg.name
 
 
 class Support(BaseSettings):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,8 @@ os.environ["SUPPORT"] = str(Path(__file__).parent / "samples" / "epics" / "suppo
 
 # The `noqa`s on these imports are necessary because of the above
 from ibek.__main__ import cli  # noqa: E402
-from ibek.ioc import clear_entity_model_ids, make_entity_models  # noqa: E402
+from ibek.entity_model import make_entity_models  # noqa: E402
+from ibek.ioc import clear_entity_model_ids  # noqa: E402
 from ibek.support import Support  # noqa: E402
 
 runner = CliRunner()

--- a/tests/samples/schemas/ibek.support.schema.json
+++ b/tests/samples/schemas/ibek.support.schema.json
@@ -39,6 +39,76 @@
       "title": "BoolArg",
       "type": "object"
     },
+    "CollectionDefinition": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "Publish Definition as type <module>.<name> for IOC instances",
+          "title": "Name",
+          "type": "string"
+        },
+        "description": {
+          "description": "A description of the Support module defined here",
+          "title": "Description",
+          "type": "string"
+        },
+        "args": {
+          "default": [],
+          "description": "The arguments IOC instance should supply",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/FloatArg"
+              },
+              {
+                "$ref": "#/$defs/StrArg"
+              },
+              {
+                "$ref": "#/$defs/IntArg"
+              },
+              {
+                "$ref": "#/$defs/BoolArg"
+              },
+              {
+                "$ref": "#/$defs/ObjectArg"
+              },
+              {
+                "$ref": "#/$defs/IdArg"
+              },
+              {
+                "$ref": "#/$defs/EnumArg"
+              }
+            ]
+          },
+          "title": "Args",
+          "type": "array"
+        },
+        "values": {
+          "default": [],
+          "description": "Calculated values to use as additional arguments",
+          "items": {
+            "$ref": "#/$defs/Value"
+          },
+          "title": "Values",
+          "type": "array"
+        },
+        "entities": {
+          "default": [],
+          "description": "The entities that this collection is to instantiate",
+          "items": {
+            "$ref": "#/$defs/Entity"
+          },
+          "title": "Entities",
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "description"
+      ],
+      "title": "CollectionDefinition",
+      "type": "object"
+    },
     "Comment": {
       "additionalProperties": false,
       "description": "A script snippet that will have '# ' prepended to every line\nfor insertion into the startup script",
@@ -224,6 +294,28 @@
         "description"
       ],
       "title": "Definition",
+      "type": "object"
+    },
+    "Entity": {
+      "additionalProperties": false,
+      "description": "A baseclass for all generated Entity classes.",
+      "properties": {
+        "type": {
+          "description": "The type of this entity",
+          "title": "Type",
+          "type": "string"
+        },
+        "entity_enabled": {
+          "default": true,
+          "description": "enable or disable this entity instance",
+          "title": "Entity Enabled",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "Entity",
       "type": "object"
     },
     "EntityPVI": {
@@ -610,7 +702,14 @@
     "defs": {
       "description": "The definitions an IOC can create using this module",
       "items": {
-        "$ref": "#/$defs/Definition"
+        "anyOf": [
+          {
+            "$ref": "#/$defs/Definition"
+          },
+          {
+            "$ref": "#/$defs/CollectionDefinition"
+          }
+        ]
       },
       "title": "Defs",
       "type": "array"

--- a/tests/samples/schemas/ibek.support.schema.json
+++ b/tests/samples/schemas/ibek.support.schema.json
@@ -152,7 +152,7 @@
         },
         "values": {
           "default": [],
-          "description": "The values IOC instance should supply",
+          "description": "Calculated values to use as additional arguments",
           "items": {
             "$ref": "#/$defs/Value"
           },

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -7,7 +7,8 @@ from pathlib import Path
 import pytest
 from ruamel.yaml import YAML
 
-from ibek.ioc import clear_entity_model_ids, make_entity_models, make_ioc_model
+from ibek.entity_model import make_entity_models, make_ioc_model
+from ibek.ioc import clear_entity_model_ids
 from ibek.support import Support
 from ibek.utils import UTILS
 from tests.conftest import run_cli

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2,6 +2,7 @@
 Some unit tests for ibek.
 """
 
+from ibek.args import IdArg, ObjectArg
 from ibek.commands import semver_compare
 from ibek.ioc import (
     clear_entity_model_ids,
@@ -9,7 +10,7 @@ from ibek.ioc import (
     make_entity_models,
     make_ioc_model,
 )
-from ibek.support import Definition, IdArg, ObjectArg, Support
+from ibek.support import Definition, Support
 
 
 def test_object_references():

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -4,12 +4,8 @@ Some unit tests for ibek.
 
 from ibek.args import IdArg, ObjectArg
 from ibek.commands import semver_compare
-from ibek.ioc import (
-    clear_entity_model_ids,
-    id_to_entity,
-    make_entity_models,
-    make_ioc_model,
-)
+from ibek.entity_model import make_entity_models, make_ioc_model
+from ibek.ioc import clear_entity_model_ids, id_to_entity
 from ibek.support import Definition, Support
 
 


### PR DESCRIPTION
This pull request will add the ability to create 'sub-entities' by making the support object 'defs' a list of Union of Definitions (as it previously was) or 'CollectionDefinitions'. 

CollectionDefinitions will have a set of arguments, just like definitions but instead of database / pre_init etc. will list a set of Entities to instantiate as sub objects.

The first pass of this PR is just a restructure to provide the above Union in the defs list. The support.py module needed breaking apart so that there were no circular dependencies. This new structure is probably tidier than it was before - the modules are now more concise and target a specific feature.