### PR TITLE
Rework the Globals Paths and their use in tests

### DIFF
--- a/src/ibek/dev_cmds/commands.py
+++ b/src/ibek/dev_cmds/commands.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import typer
 
-from ibek.globals import CONFIG_DIR_NAME, IOC_FOLDER, NaturalOrderGroup
+from ibek.globals import GLOBALS, NaturalOrderGroup
 
 log = logging.getLogger(__name__)
 dev_cli = typer.Typer(cls=NaturalOrderGroup)
@@ -34,9 +34,9 @@ def instance(
     """
 
     # validate the instance folder has a config folder
-    ioc_folder = IOC_FOLDER
-    config_folder = ioc_folder / CONFIG_DIR_NAME
-    instance_config = instance / CONFIG_DIR_NAME
+    ioc_folder = GLOBALS.IOC_FOLDER
+    config_folder = ioc_folder / GLOBALS.CONFIG_DIR_NAME
+    instance_config = instance / GLOBALS.CONFIG_DIR_NAME
 
     # verify that the expected folder exists
     if not ioc_folder.exists():

--- a/src/ibek/globals.py
+++ b/src/ibek/globals.py
@@ -12,77 +12,132 @@ DEFAULT_ARCH = "linux-x86_64"
 
 
 class _Globals:
-    """Helper class for accessing global constants."""
+    """
+    Helper class for accessing global constants.
+
+    These constants define the paths to the various directories used by the
+    ibek commands.
+    """
 
     def __init__(self) -> None:
-        self.EPICS_ROOT = Path(os.getenv("EPICS_ROOT", "/epics/"))
-        """
-        Root of epics directory tree.
+        """Initialize the global constants."""
 
-        Can be overridden by defining an environment variable "EPICS_ROOT".
-        """
+        # Can be overridden by defining an environment variable "EPICS_ROOT"
+        self._EPICS_ROOT = Path(os.getenv("EPICS_ROOT", "/epics/"))
 
-        self.SUPPORT = self.EPICS_ROOT / "support"
-        """
-        Directory containing support module clones
+        self._DEFAULT_ARCH = "linux-x86_64"
 
-        Can be overridden by defining an environment variable "SUPPORT"."
-        """
+    @property
+    def EPICS_ROOT(self):
+        """Root of epics directory tree"""
+        return self._EPICS_ROOT
 
-        self.RELEASE = self.EPICS_ROOT / "support" / "configure" / "RELEASE"
+    @property
+    def SUPPORT(self):
+        """Directory containing support module clones"""
+        return self._EPICS_ROOT / "support"
+
+    @property
+    def RELEASE(self):
         """The global RELEASE file which lists all support modules"""
+        return self._EPICS_ROOT / "support" / "configure" / "RELEASE"
 
-        self.IBEK_DEFS = self.EPICS_ROOT / "ibek-defs"
-        """Directory containing ibek support yaml definitions."""
-
-        self.PVI_DEFS = self.EPICS_ROOT / "pvi-defs"
-        """Directory containing pvi device yaml definitions."""
-
-        self.RUNTIME_OUTPUT = self.EPICS_ROOT / "runtime"
+    @property
+    def RUNTIME_OUTPUT(self):
         """Directory containing runtime generated assets for IOC boot."""
+        return self._EPICS_ROOT / "runtime"
 
-        self.OPI_OUTPUT = self.EPICS_ROOT / "opi"
-        """Directory containing runtime generated opis to serve over http."""
-
-        self.EPICS_TARGET_ARCH = os.getenv("EPICS_TARGET_ARCH", DEFAULT_ARCH)
+    @property
+    def EPICS_TARGET_ARCH(self):
         """The target architecture for the current container."""
+        return os.getenv("EPICS_TARGET_ARCH", self._DEFAULT_ARCH)
 
-        self.EPICS_HOST_ARCH = os.getenv("EPICS_HOST_ARCH", DEFAULT_ARCH)
+    @property
+    def EPICS_HOST_ARCH(self):
         """The host architecture for the current container."""
+        return os.getenv("EPICS_HOST_ARCH", self._DEFAULT_ARCH)
 
-        self.NATIVE = self.EPICS_TARGET_ARCH == self.EPICS_HOST_ARCH
+    @property
+    def NATIVE(self):
         """True if the target architecture is the same as the host architecture."""
+        return self.EPICS_TARGET_ARCH == self.EPICS_HOST_ARCH
 
-        default_static: bool = self.EPICS_TARGET_ARCH != DEFAULT_ARCH
-        self.STATIC_BUILD = os.getenv("STATIC_BUILD", default_static)
+    @property
+    def STATIC_BUILD(self):
+        """True if the target architecture is not the default architecture."""
+        return os.getenv("STATIC_BUILD", self._EPICS_TARGET_ARCH != self._DEFAULT_ARCH)
 
+    @property
+    def IBEK_DEFS(self):
+        """Directory containing ibek support yaml definitions."""
+        return self._EPICS_ROOT / "ibek-defs"
 
-GLOBALS = _Globals()
+    @property
+    def PVI_DEFS(self):
+        """Directory containing pvi device yaml definitions."""
+        return self._EPICS_ROOT / "pvi-defs"
+        return self._EPICS_ROOT / "pvi-defs"
 
-# TODO: Include all constants in _Globals
+    @property
+    def OPI_OUTPUT(self):
+        """Directory containing runtime generated opis to serve over http."""
+        return self._EPICS_ROOT / "opi"
 
-# get the container paths from environment variables
-EPICS_BASE = Path(os.getenv("EPICS_BASE", "/epics/epics-base"))
-IOC_FOLDER = Path(os.getenv("IOC", "/epics/ioc"))
-CONFIG_DIR_NAME = "config"
-IOC_DIR_NAME = "ioc"
+    @property
+    def EPICS_BASE(self):
+        """xx"""
+        return self._EPICS_ROOT / "epics-base"
 
-# a bash script to export the macros defined in RELEASE as environment vars
-RELEASE_SH = GLOBALS.SUPPORT / "configure/RELEASE.shell"
-# global MODULES file used to determine order of build
-MODULES = GLOBALS.SUPPORT / "configure/MODULES"
+    @property
+    def IOC_FOLDER(self):
+        """root folder of a generic IOC source inside the container"""
+        return self._EPICS_ROOT / "ioc"
+
+    @property
+    def CONFIG_DIR_NAME(self):
+        """configuration directory name for the IOC"""
+        return "config"
+
+    @property
+    def IOC_DIR_NAME(self):
+        """folder of the IOC source"""
+        return "ioc"
+
+    @property
+    def RELEASE_SH(self):
+        """a bash script to export the macros defined in RELEASE as environment vars"""
+        return self.SUPPORT / "configure" / "RELEASE.shell"
+
+    @property
+    def MODULES(self):
+        """global MODULES file used to determine order of build"""
+        return self.SUPPORT / "configure" / "MODULES"
+
+    @property
+    def IOC_DBDS(self):
+        """ibek-support list of declared dbds"""
+        return self.SUPPORT / "configure" / "dbd_list"
+
+    @property
+    def IOC_LIBS(self):
+        """ibek-support list of declared libs"""
+        return self.SUPPORT / "configure" / "lib_list"
+
+    @property
+    def RUNTIME_DEBS(self):
+        """ibek-support list of declared libs"""
+        return self.SUPPORT / "configure" / "runtime_debs"
+
 
 # Folder containing templates for IOC src etc.
 TEMPLATES = Path(__file__).parent / "templates"
 
-# Paths for ibek-support
+# Path suffixes for ibek-support
 IBEK_GLOBALS = Path("_global")
 SUPPORT_YAML_PATTERN = "*ibek.support.yaml"
 PVI_YAML_PATTERN = "*pvi.device.yaml"
 
-IOC_DBDS = GLOBALS.SUPPORT / "configure/dbd_list"
-IOC_LIBS = GLOBALS.SUPPORT / "configure/lib_list"
-RUNTIME_DEBS = GLOBALS.SUPPORT / "configure/runtime_debs"
+GLOBALS = _Globals()
 
 
 class BaseSettings(BaseModel):

--- a/src/ibek/globals.py
+++ b/src/ibek/globals.py
@@ -76,7 +76,6 @@ class _Globals:
     def PVI_DEFS(self):
         """Directory containing pvi device yaml definitions."""
         return self._EPICS_ROOT / "pvi-defs"
-        return self._EPICS_ROOT / "pvi-defs"
 
     @property
     def OPI_OUTPUT(self):
@@ -85,7 +84,7 @@ class _Globals:
 
     @property
     def EPICS_BASE(self):
-        """xx"""
+        """The folder containing the epics base source and binaries"""
         return self._EPICS_ROOT / "epics-base"
 
     @property
@@ -95,7 +94,7 @@ class _Globals:
 
     @property
     def CONFIG_DIR_NAME(self):
-        """configuration directory name for the IOC"""
+        """Name of config directory within IOC directory"""
         return "config"
 
     @property

--- a/src/ibek/ioc_cmds/assets.py
+++ b/src/ibek/ioc_cmds/assets.py
@@ -67,7 +67,9 @@ def extract_assets(
                 GLOBALS.IOC_FOLDER
             ).parent,  # get contents of IOC folder and its source (parent)
             Path("/venv"),  # get the virtualenv
-        ] + list(source.glob("ibek*"))  # get ibek-support and related folders
+        ] + list(
+            source.glob("ibek*")
+        )  # get ibek-support and related folders
     else:
         default_assets = []
 

--- a/src/ibek/ioc_cmds/assets.py
+++ b/src/ibek/ioc_cmds/assets.py
@@ -7,7 +7,7 @@ from typing import List
 
 import typer
 
-from ibek.globals import GLOBALS, IOC_FOLDER
+from ibek.globals import GLOBALS
 
 log = logging.getLogger(__name__)
 
@@ -62,14 +62,12 @@ def extract_assets(
             source / "support" / "configure",
             GLOBALS.PVI_DEFS,
             GLOBALS.IBEK_DEFS,
-            IOC_FOLDER,  # get the IOC folder symlink
+            GLOBALS.IOC_FOLDER,  # get the IOC folder symlink
             Path.readlink(
-                IOC_FOLDER
+                GLOBALS.IOC_FOLDER
             ).parent,  # get contents of IOC folder and its source (parent)
             Path("/venv"),  # get the virtualenv
-        ] + list(
-            source.glob("ibek*")
-        )  # get ibek-support and related folders
+        ] + list(source.glob("ibek*"))  # get ibek-support and related folders
     else:
         default_assets = []
 

--- a/src/ibek/ioc_cmds/commands.py
+++ b/src/ibek/ioc_cmds/commands.py
@@ -30,7 +30,8 @@ def build_docker(
             help="The filepath to the Dockerfile to build",
             autocompletion=lambda: [],  # Forces path autocompletion
         ),
-    ] = Path.cwd() / "Dockerfile",
+    ] = Path.cwd()
+    / "Dockerfile",
 ):
     """
     EXPERIMENTAL: Attempt to interpret the Dockerfile and run it's commands

--- a/src/ibek/support_cmds/checks.py
+++ b/src/ibek/support_cmds/checks.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import typer
 
-from ibek.globals import GLOBALS, MODULES, RELEASE_SH, TEMPLATES
+from ibek.globals import GLOBALS, TEMPLATES
 
 # turn RELEASE macros into bash macros
 SHELL_FIND = re.compile(r"\$\(([^\)]*)\)")
@@ -62,7 +62,7 @@ def do_dependencies():
     if "IOC" in global_release_paths:
         paths.append(global_release_paths["IOC"])
     mod_list = f'MODULES := {" ".join(paths)}\n'
-    MODULES.write_text(mod_list)
+    GLOBALS.MODULES.write_text(mod_list)
 
     # generate RELEASE.shell file for inclusion into the ioc launch shell script.
     # This adds all module paths to the environment and also adds their db
@@ -79,7 +79,7 @@ def do_dependencies():
 
     shell_text = "\n".join(release_sh) + "\n"
     shell_text = SHELL_FIND.sub(SHELL_REPLACE, shell_text)
-    RELEASE_SH.write_text(shell_text)
+    GLOBALS.RELEASE_SH.write_text(shell_text)
 
 
 def check_deps(deps: list[str]) -> None:

--- a/src/ibek/support_cmds/commands.py
+++ b/src/ibek/support_cmds/commands.py
@@ -18,10 +18,7 @@ from typing_extensions import Annotated
 from ibek.globals import (
     GLOBALS,
     IBEK_GLOBALS,
-    IOC_DBDS,
-    IOC_LIBS,
     PVI_YAML_PATTERN,
-    RUNTIME_DEBS,
     SUPPORT_YAML_PATTERN,
     NaturalOrderGroup,
 )
@@ -113,7 +110,7 @@ def add_runtime_packages(
     The list may include any additional 'apt-get install' options required.
     """
     debs = debs or []
-    add_list_to_file(RUNTIME_DEBS, debs)
+    add_list_to_file(GLOBALS.RUNTIME_DEBS, debs)
 
 
 @support_cli.command()
@@ -129,8 +126,8 @@ def apt_install_runtime_packages(
         print("skipping runtime install in cross-compile environment")
         return
 
-    if RUNTIME_DEBS.exists():
-        debs = RUNTIME_DEBS.read_text().split()
+    if GLOBALS.RUNTIME_DEBS.exists():
+        debs = GLOBALS.RUNTIME_DEBS.read_text().split()
         _install_debs(debs)
 
 
@@ -211,7 +208,7 @@ def add_libs(
     declare the libraries for this support module for inclusion in IOC Makefile
     """
     libs = libs or []
-    add_list_to_file(IOC_LIBS, libs)
+    add_list_to_file(GLOBALS.IOC_LIBS, libs)
 
 
 @support_cli.command()
@@ -222,7 +219,6 @@ def add_dbds(
     declare the dbd files for this support module for inclusion in IOC Makefile
     """
     dbds = dbds or []
-    add_list_to_file(IOC_DBDS, dbds)
 
 
 @support_cli.command()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,11 +60,13 @@ def entity_factory():
 
 
 @fixture
-def epics_root(samples: Path, tmp_path: Path, mocker: MockerFixture):
+def tmp_epics_root(samples: Path, tmp_path: Path, mocker: MockerFixture):
     # create an partially populated epics_root structure in a temporary folder
     epics = tmp_path / "epics"
-    shutil.copytree(samples / "epics", epics)
-    Path.mkdir(epics / "opi", exist_ok=True)
+    epics.mkdir()
+    shutil.copytree(samples / "epics" / "pvi-defs", epics / "pvi-defs")
+    shutil.copytree(samples / "epics" / "support", epics / "support")
+    Path.mkdir(epics / "opi")
     Path.mkdir(epics / "epics-base")
     Path.mkdir(epics / "ioc/config", parents=True)
     Path.mkdir(epics / "ibek-defs")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,7 +80,7 @@ def test_motor_sim_schema(tmp_path: Path, samples: Path):
     assert expected == actual
 
 
-def test_build_runtime_motorSim(epics_root: Path, samples: Path):
+def test_build_runtime_motorSim(tmp_epics_root: Path, samples: Path):
     """
     build an ioc runtime script from an IOC instance entity file
     and multiple support module definition files
@@ -96,27 +96,27 @@ def test_build_runtime_motorSim(epics_root: Path, samples: Path):
     generate(ioc_yaml, [support_yaml1, support_yaml2])
 
     example_boot = (expected_outputs / "st.cmd").read_text()
-    actual_boot = (epics_root / "runtime" / "st.cmd").read_text()
+    actual_boot = (tmp_epics_root / "runtime" / "st.cmd").read_text()
     assert example_boot == actual_boot
 
     example_db = (expected_outputs / "ioc.subst").read_text()
-    actual_db = (epics_root / "runtime" / "ioc.subst").read_text()
+    actual_db = (tmp_epics_root / "runtime" / "ioc.subst").read_text()
     assert example_db == actual_db
 
     example_index = (expected_outputs / "index.bob").read_text()
-    actual_index = (epics_root / "opi" / "index.bob").read_text()
+    actual_index = (tmp_epics_root / "opi" / "index.bob").read_text()
     assert example_index == actual_index
 
     example_bob = (expected_outputs / "simple.pvi.bob").read_text()
-    actual_bob = (epics_root / "opi" / "simple.pvi.bob").read_text()
+    actual_bob = (tmp_epics_root / "opi" / "simple.pvi.bob").read_text()
     assert example_bob == actual_bob
 
     example_template = (expected_outputs / "simple.pvi.template").read_text()
-    actual_template = (epics_root / "runtime" / "simple.pvi.template").read_text()
+    actual_template = (tmp_epics_root / "runtime" / "simple.pvi.template").read_text()
     assert example_template == actual_template
 
 
-def test_build_utils_features(epics_root: Path, samples: Path):
+def test_build_utils_features(tmp_epics_root: Path, samples: Path):
     """
     build an ioc runtime script to verify utils features
     """
@@ -126,11 +126,11 @@ def test_build_utils_features(epics_root: Path, samples: Path):
     run_cli("runtime", "generate", ioc_yaml, support_yaml)
 
     example_boot = (samples / "outputs" / "utils" / "st.cmd").read_text()
-    actual_boot = (epics_root / "runtime" / "st.cmd").read_text()
+    actual_boot = (tmp_epics_root / "runtime" / "st.cmd").read_text()
     assert example_boot == actual_boot
 
     example_db = (samples / "outputs" / "utils" / "ioc.subst").read_text()
-    actual_db = (epics_root / "runtime" / "ioc.subst").read_text()
+    actual_db = (tmp_epics_root / "runtime" / "ioc.subst").read_text()
     assert example_db == actual_db
 
 
@@ -147,7 +147,7 @@ def test_generate_links_ibek(samples: Path, mocker: MockerFixture):
     )
 
 
-def test_ipac(epics_root: Path, samples: Path):
+def test_ipac(tmp_epics_root: Path, samples: Path):
     """
     Tests that an id argument can include another argument in its default value
     """
@@ -164,11 +164,11 @@ def test_ipac(epics_root: Path, samples: Path):
     generate(ioc_yaml, [support_yaml1, support_yaml2])
 
     example_boot = (expected_outputs / "st.cmd").read_text()
-    actual_boot = (epics_root / "runtime" / "st.cmd").read_text()
+    actual_boot = (tmp_epics_root / "runtime" / "st.cmd").read_text()
     assert example_boot == actual_boot
 
 
-def test_gauges(epics_root: Path, samples: Path):
+def test_gauges(tmp_epics_root: Path, samples: Path):
     """
     Tests that an id argument can include another argument in its default value
     """
@@ -180,11 +180,11 @@ def test_gauges(epics_root: Path, samples: Path):
     generate(ioc_yaml, [support_yaml1, support_yaml2])
 
     example_boot = (expected_outputs / "st.cmd").read_text()
-    actual_boot = (epics_root / "runtime" / "st.cmd").read_text()
+    actual_boot = (tmp_epics_root / "runtime" / "st.cmd").read_text()
     assert example_boot == actual_boot
 
 
-def test_quadem(epics_root: Path, samples: Path):
+def test_quadem(tmp_epics_root: Path, samples: Path):
     """
     Tests the use of CollectionDefinitions in an IOC instance
     this example uses the tetramm beam position monitor module
@@ -197,9 +197,9 @@ def test_quadem(epics_root: Path, samples: Path):
     generate(ioc_yaml, [support_yaml1, support_yaml2])
 
     example_boot = (expected_outputs / "st.cmd").read_text()
-    actual_boot = (epics_root / "runtime" / "st.cmd").read_text()
+    actual_boot = (tmp_epics_root / "runtime" / "st.cmd").read_text()
     assert example_boot == actual_boot
 
     example_db = (samples / "outputs" / "quadem" / "ioc.subst").read_text()
-    actual_db = (epics_root / "runtime" / "ioc.subst").read_text()
+    actual_db = (tmp_epics_root / "runtime" / "ioc.subst").read_text()
     assert example_db == actual_db

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,6 @@ results.
 """
 
 import json
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -81,7 +80,7 @@ def test_motor_sim_schema(tmp_path: Path, samples: Path):
     assert expected == actual
 
 
-def test_build_runtime_motorSim(mocker: MockerFixture, tmp_path: Path, samples: Path):
+def test_build_runtime_motorSim(epics_root: Path, samples: Path):
     """
     build an ioc runtime script from an IOC instance entity file
     and multiple support module definition files
@@ -94,53 +93,44 @@ def test_build_runtime_motorSim(mocker: MockerFixture, tmp_path: Path, samples: 
     support_yaml2 = samples / "support" / "motorSim.ibek.support.yaml"
     expected_outputs = samples / "outputs" / "motorSim"
 
-    mocker.patch.object(GLOBALS, "RUNTIME_OUTPUT", tmp_path)
-    mocker.patch.object(GLOBALS, "OPI_OUTPUT", tmp_path)
-    mocker.patch.object(GLOBALS, "PVI_DEFS", samples / "epics" / "pvi-defs")
-    os.environ["IOC"] = "/epics/ioc"
-    os.environ["RUNTIME_DIR"] = "/epics/runtime"
     generate(ioc_yaml, [support_yaml1, support_yaml2])
 
     example_boot = (expected_outputs / "st.cmd").read_text()
-    actual_boot = (tmp_path / "st.cmd").read_text()
+    actual_boot = (epics_root / "runtime" / "st.cmd").read_text()
     assert example_boot == actual_boot
 
     example_db = (expected_outputs / "ioc.subst").read_text()
-    actual_db = (tmp_path / "ioc.subst").read_text()
+    actual_db = (epics_root / "runtime" / "ioc.subst").read_text()
     assert example_db == actual_db
 
     example_index = (expected_outputs / "index.bob").read_text()
-    actual_index = (tmp_path / "index.bob").read_text()
+    actual_index = (epics_root / "opi" / "index.bob").read_text()
     assert example_index == actual_index
 
     example_bob = (expected_outputs / "simple.pvi.bob").read_text()
-    actual_bob = (tmp_path / "simple.pvi.bob").read_text()
+    actual_bob = (epics_root / "opi" / "simple.pvi.bob").read_text()
     assert example_bob == actual_bob
 
     example_template = (expected_outputs / "simple.pvi.template").read_text()
-    actual_template = (tmp_path / "simple.pvi.template").read_text()
+    actual_template = (epics_root / "runtime" / "simple.pvi.template").read_text()
     assert example_template == actual_template
 
 
-def test_build_utils_features(mocker: MockerFixture, tmp_path: Path, samples: Path):
+def test_build_utils_features(epics_root: Path, samples: Path):
     """
     build an ioc runtime script to verify utils features
     """
     ioc_yaml = samples / "iocs" / "utils.ibek.ioc.yaml"
     support_yaml = samples / "support" / "utils.ibek.support.yaml"
 
-    mocker.patch.object(GLOBALS, "RUNTIME_OUTPUT", tmp_path)
-
-    os.environ["IOC"] = "/epics/ioc"
-    os.environ["RUNTIME_DIR"] = "/epics/runtime"
     run_cli("runtime", "generate", ioc_yaml, support_yaml)
 
     example_boot = (samples / "outputs" / "utils" / "st.cmd").read_text()
-    actual_boot = (tmp_path / "st.cmd").read_text()
+    actual_boot = (epics_root / "runtime" / "st.cmd").read_text()
     assert example_boot == actual_boot
 
     example_db = (samples / "outputs" / "utils" / "ioc.subst").read_text()
-    actual_db = (tmp_path / "ioc.subst").read_text()
+    actual_db = (epics_root / "runtime" / "ioc.subst").read_text()
     assert example_db == actual_db
 
 
@@ -157,7 +147,7 @@ def test_generate_links_ibek(samples: Path, mocker: MockerFixture):
     )
 
 
-def test_ipac(mocker: MockerFixture, tmp_path: Path, samples: Path):
+def test_ipac(epics_root: Path, samples: Path):
     """
     Tests that an id argument can include another argument in its default value
     """
@@ -167,23 +157,18 @@ def test_ipac(mocker: MockerFixture, tmp_path: Path, samples: Path):
     support_yaml2 = samples / "support" / "epics.ibek.support.yaml"
     expected_outputs = samples / "outputs" / "ipac"
 
-    mocker.patch.object(GLOBALS, "RUNTIME_OUTPUT", tmp_path)
-    mocker.patch.object(GLOBALS, "OPI_OUTPUT", tmp_path)
-
     # reset the InterruptVector counter to its initial state (if already used)
     if "InterruptVector" in utils.UTILS.counters:
         utils.UTILS.counters["InterruptVector"].current = 192
 
-    os.environ["IOC"] = "/epics/ioc"
-    os.environ["RUNTIME_DIR"] = "/epics/runtime"
     generate(ioc_yaml, [support_yaml1, support_yaml2])
 
     example_boot = (expected_outputs / "st.cmd").read_text()
-    actual_boot = (tmp_path / "st.cmd").read_text()
+    actual_boot = (epics_root / "runtime" / "st.cmd").read_text()
     assert example_boot == actual_boot
 
 
-def test_gauges(mocker: MockerFixture, tmp_path: Path, samples: Path):
+def test_gauges(epics_root: Path, samples: Path):
     """
     Tests that an id argument can include another argument in its default value
     """
@@ -192,19 +177,14 @@ def test_gauges(mocker: MockerFixture, tmp_path: Path, samples: Path):
     support_yaml2 = samples / "support" / "gauges.ibek.support.yaml"
     expected_outputs = samples / "outputs" / "gauges"
 
-    mocker.patch.object(GLOBALS, "RUNTIME_OUTPUT", tmp_path)
-    mocker.patch.object(GLOBALS, "OPI_OUTPUT", tmp_path)
-
-    os.environ["IOC"] = "/epics/ioc"
-    os.environ["RUNTIME_DIR"] = "/epics/runtime"
     generate(ioc_yaml, [support_yaml1, support_yaml2])
 
     example_boot = (expected_outputs / "st.cmd").read_text()
-    actual_boot = (tmp_path / "st.cmd").read_text()
+    actual_boot = (epics_root / "runtime" / "st.cmd").read_text()
     assert example_boot == actual_boot
 
 
-def test_quadem(mocker: MockerFixture, tmp_path: Path, samples: Path):
+def test_quadem(epics_root: Path, samples: Path):
     """
     Tests the use of CollectionDefinitions in an IOC instance
     this example uses the tetramm beam position monitor module
@@ -214,18 +194,12 @@ def test_quadem(mocker: MockerFixture, tmp_path: Path, samples: Path):
     support_yaml2 = samples / "support" / "quadem.ibek.support.yaml"
     expected_outputs = samples / "outputs" / "quadem"
 
-    mocker.patch.object(GLOBALS, "RUNTIME_OUTPUT", tmp_path)
-    mocker.patch.object(GLOBALS, "OPI_OUTPUT", tmp_path)
-    mocker.patch.object(GLOBALS, "PVI_DEFS", samples / "epics" / "pvi-defs")
-    os.environ["IOC"] = "/epics/ioc"
-    os.environ["RUNTIME_DIR"] = "/epics/runtime"
-
     generate(ioc_yaml, [support_yaml1, support_yaml2])
 
     example_boot = (expected_outputs / "st.cmd").read_text()
-    actual_boot = (tmp_path / "st.cmd").read_text()
+    actual_boot = (epics_root / "runtime" / "st.cmd").read_text()
     assert example_boot == actual_boot
 
     example_db = (samples / "outputs" / "quadem" / "ioc.subst").read_text()
-    actual_db = (tmp_path / "ioc.subst").read_text()
+    actual_db = (epics_root / "runtime" / "ioc.subst").read_text()
     assert example_db == actual_db

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -13,7 +13,7 @@ from ibek.utils import UTILS
 from tests.conftest import run_cli
 
 
-def test_counter_reuse(samples: Path):
+def test_counter_reuse(epics_root: Path, samples: Path):
     """
     Check you cannot redefine a counter with the same name and different params
     """
@@ -30,7 +30,7 @@ def test_counter_reuse(samples: Path):
     )
 
 
-def test_counter_overuse(samples: Path):
+def test_counter_overuse(epics_root: Path, samples: Path):
     """
     Check that counter limits are enforced
     """
@@ -45,7 +45,7 @@ def test_counter_overuse(samples: Path):
     assert "Counter 195 exceeded stop value of 194" in str(ctx.value)
 
 
-def test_bad_ref(tmp_path: Path, samples: Path):
+def test_bad_ref(samples: Path):
     """
     Check bad object references are caught
     """
@@ -60,7 +60,7 @@ def test_bad_ref(tmp_path: Path, samples: Path):
     assert "object controllerOnePort_BAD_REF not found" in str(ctx.value)
 
 
-def test_bad_db(tmp_path: Path, samples: Path):
+def test_bad_db(epics_root: Path, samples: Path):
     """
     Check bad database args are caught
     """
@@ -74,7 +74,7 @@ def test_bad_db(tmp_path: Path, samples: Path):
     assert "'non-existant' in database template 'test.db' not found" in str(ctx.value)
 
 
-def test_loading_module_twice(entity_factory, tmp_path: Path, samples: Path):
+def test_loading_module_twice(entity_factory, samples: Path):
     """
     Verify we get a sensible error if we try to load a module twice
     without clearing the entity model ids

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -13,7 +13,7 @@ from ibek.utils import UTILS
 from tests.conftest import run_cli
 
 
-def test_counter_reuse(epics_root: Path, samples: Path):
+def test_counter_reuse(tmp_epics_root: Path, samples: Path):
     """
     Check you cannot redefine a counter with the same name and different params
     """
@@ -30,7 +30,7 @@ def test_counter_reuse(epics_root: Path, samples: Path):
     )
 
 
-def test_counter_overuse(epics_root: Path, samples: Path):
+def test_counter_overuse(tmp_epics_root: Path, samples: Path):
     """
     Check that counter limits are enforced
     """
@@ -60,7 +60,7 @@ def test_bad_ref(samples: Path):
     assert "object controllerOnePort_BAD_REF not found" in str(ctx.value)
 
 
-def test_bad_db(epics_root: Path, samples: Path):
+def test_bad_db(tmp_epics_root: Path, samples: Path):
     """
     Check bad database args are caught
     """

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -3,9 +3,7 @@
 from pathlib import Path
 
 import pytest
-from pytest_mock import MockerFixture
 
-from ibek.globals import GLOBALS
 from ibek.support_cmds.checks import check_deps
 from ibek.support_cmds.files import symlink_files
 
@@ -32,9 +30,9 @@ def test_symlink_pvi(tmp_path: Path, samples: Path):
     assert [f.name for f in tmp_path.iterdir()] == ["simple.pvi.device.yaml"]
 
 
-def test_check_dependencies(mocker: MockerFixture, samples: Path):
-    mocker.patch.object(GLOBALS, "RELEASE", samples / "epics/support/configure/RELEASE")
-    mocker.patch.object(GLOBALS, "SUPPORT", samples / "epics/support/")
+# note this must refer to epics_root to patch where check_deps looks for
+# the support files
+def test_check_dependencies(epics_root: Path):
     # Check Passes vs test data
     check_deps(["ADSimDetector"])
 

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -32,7 +32,7 @@ def test_symlink_pvi(tmp_path: Path, samples: Path):
 
 # note this must refer to epics_root to patch where check_deps looks for
 # the support files
-def test_check_dependencies(epics_root: Path):
+def test_check_dependencies(tmp_epics_root: Path):
     # Check Passes vs test data
     check_deps(["ADSimDetector"])
 


### PR DESCRIPTION
Created a new pytest fixture `epics_root` which creates a new partly populated epics folder in tmp and patches globals to point at it.

This way most tests just need to reference that fixture and all is much tidier. honest.