### PR TITLE
Skip system testing by default

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -46,6 +46,7 @@ jobs:
       PY_IGNORE_IMPORTMISMATCH: "1"
       # enable QT tests with no X Display
       QT_QPA_PLATFORM: "offscreen"
+      IBEK_SYSTEM_TESTING: "true"
 
     steps:
       - name: Checkout

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -32,6 +32,10 @@ def run_command(command: str, error_OK=False, show=False):
 
 
 @pytest.mark.skipif(
+    os.getenv("IBEK_SYSTEM_TESTING") != "true",
+    reason="export IBEK_SYSTEM_TESTING=true",
+)
+@pytest.mark.skipif(
     os.getenv("REMOTE_CONTAINERS") == "true", reason="only run outside devcontainers"
 )
 def test_container_build_and_run(tmp_path: Path):


### PR DESCRIPTION
System test requires permissions to execute from /temp/

Checked that system test still runs on GHA - https://github.com/epics-containers/ibek/actions/runs/9171396742/job/25215628270#step:5:53