### PR TITLE
Improve jinja capabilities further

### DIFF
--- a/src/ibek/args.py
+++ b/src/ibek/args.py
@@ -90,7 +90,9 @@ class ObjectArg(Arg):
     """A reference to another entity defined in this IOC"""
 
     type: Literal["object"] = "object"
-    default: Optional[str] = None
+    # represented by an id string in YAML but converted to an Entity object
+    # during validation
+    default: Optional[str | object] = None
 
 
 class IdArg(Arg):

--- a/src/ibek/entity_factory.py
+++ b/src/ibek/entity_factory.py
@@ -8,14 +8,14 @@ import builtins
 from pathlib import Path
 from typing import Annotated, Any, Dict, List, Literal, Sequence, Tuple, Type
 
-from pydantic import Field, create_model, field_validator
+from pydantic import Field, create_model
 from pydantic_core import PydanticUndefined, ValidationError
 from ruamel.yaml.main import YAML
 
 from ibek.globals import JINJA
 
 from .args import EnumArg, IdArg, ObjectArg, Value
-from .ioc import Entity, EnumVal, clear_entity_model_ids, get_entity_by_id
+from .ioc import Entity, EnumVal, clear_entity_model_ids
 from .support import EntityDefinition, Support
 from .utils import UTILS
 
@@ -106,18 +106,10 @@ class EntityFactory:
 
         # add in each of the arguments as a Field in the Entity
         for arg in definition.args:
-            # TODO - don't understand why I need type ignore here
-            # arg is 'discriminated' which is a Union of all the Arg subclasses
-            full_arg_name = f"{full_name}.{arg.name}"  # type: ignore
             type: Any
 
             if isinstance(arg, ObjectArg):
-                # TODO look into why arg.name requires type ignore
-                @field_validator(arg.name, mode="after")  # type: ignore
-                def lookup_instance(cls, id):
-                    return get_entity_by_id(id)
-
-                validators[full_arg_name] = lookup_instance
+                # we now defer the lookup of the object until whole model validation
                 type = object
 
             elif isinstance(arg, IdArg):

--- a/src/ibek/ioc.py
+++ b/src/ibek/ioc.py
@@ -78,7 +78,7 @@ class Entity(BaseSettings):
                     # must be coerced back into their original type
                     try:
                         # The following replace are to make the string json compatible
-                        # (maybe we should python decode instead of json.loads?)
+                        # (maybe we should python decode instead of json.loads)
                         value = value.replace("'", '"')
                         value = value.replace("True", "true")
                         value = value.replace("False", "false")
@@ -94,10 +94,12 @@ class Entity(BaseSettings):
                 entity_dict[arg] = value
 
             if model_field.annotation == object:
-                # if the field is an object but the type is str then look up
-                # the actual object (this covers default values with obj ref)
+                # look up the actual object by it's id
                 if isinstance(value, str):
-                    setattr(self, arg, get_entity_by_id(value))
+                    value = get_entity_by_id(value)
+                    setattr(self, arg, value)
+                # update the entity_dict with looked up object
+                entity_dict[arg] = value
 
             if arg in ids:
                 # add this entity to the global id index

--- a/src/ibek/utils.py
+++ b/src/ibek/utils.py
@@ -81,13 +81,15 @@ class Utils:
 
     def set(self, key: str, value: Any) -> Any:
         """create a global variable for our jinja context"""
-        self.variables[key] = value
+        s_key = str(key)
+        self.variables[s_key] = value
         return value
 
     def get(self, key: str, default="") -> Any:
         """get the value a global variable for our jinja context"""
         # default is used to set an initial value if the variable is not set
-        return self.variables.get(key, default)
+        s_key = str(key)
+        return self.variables.get(s_key, default)
 
     def counter(
         self, name: str, start: int = 0, stop: int = 65535, inc: int = 1
@@ -97,10 +99,11 @@ class Utils:
 
         creates a new counter if it does not yet exist
         """
-        counter = self.counters.get(name)
+        index = str(name)
+        counter = self.counters.get(index)
         if counter is None:
             counter = Counter(start, start, stop)
-            self.counters[name] = counter
+            self.counters[index] = counter
         else:
             if counter.start != start or counter.stop != stop:
                 raise ValueError(
@@ -108,7 +111,7 @@ class Utils:
                 )
         result = counter.current
         counter.increment(inc)
-        self.counters[name] = counter
+        self.counters[index] = counter
 
         return result
 

--- a/src/ibek/utils.py
+++ b/src/ibek/utils.py
@@ -8,35 +8,10 @@ we pass a single instance of this class into all Jinja contexts.
 """
 
 import os
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Mapping
 
 from jinja2 import StrictUndefined, Template
-
-
-@dataclass
-class Counter:
-    """
-    Provides the ability to supply unique numbers to Jinja templates
-    """
-
-    start: int
-    current: int
-    stop: int
-
-    def increment(self, count: int):
-        self.current += count
-        if self.current > self.stop:
-            raise ValueError(
-                f"Counter {self.current} exceeded stop value of {self.stop}"
-            )
-
-    def __repr__(self) -> str:
-        return str(self.current)
-
-    def __str__(self) -> str:
-        return str(self.current)
 
 
 class Utils:
@@ -49,17 +24,12 @@ class Utils:
         self.ioc_name: str = ""
         self.__reset__()
 
-        # old names for backward compatibility
-        self.set_var = self.set
-        self.get_var = self.get
-
     def __reset__(self: "Utils"):
         """
         Reset all saved state. For use in testing where more than one
         IOC is rendered in a single session
         """
         self.variables: Dict[str, Any] = {}
-        self.counters: Dict[str, Counter] = {}
 
     def set_file_name(self: "Utils", file: Path):
         """
@@ -91,8 +61,8 @@ class Utils:
         s_key = str(key)
         return self.variables.get(s_key, default)
 
-    def counter(
-        self, name: str, start: int = 0, stop: int = 65535, inc: int = 1
+    def incrementor(
+        self, name: str, start: int = 0, increment: int = 1, stop: int = 10000
     ) -> int:
         """
         get a named counter that increments by inc each time it is called
@@ -100,20 +70,18 @@ class Utils:
         creates a new counter if it does not yet exist
         """
         index = str(name)
-        counter = self.counters.get(index)
-        if counter is None:
-            counter = Counter(start, start, stop)
-            self.counters[index] = counter
-        else:
-            if counter.start != start or counter.stop != stop:
-                raise ValueError(
-                    f"Redefining counter {name} with different start/stop values"
-                )
-        result = counter.current
-        counter.increment(inc)
-        self.counters[index] = counter
+        counter = self.variables.get(index)
 
-        return result
+        if counter is None:
+            self.variables[index] = start
+        else:
+            if not isinstance(counter, int):
+                raise ValueError(f"Variable {index} is not an integer")
+            self.variables[index] += increment
+            if self.variables[index] > stop:
+                raise ValueError(f"Counter {index} exceeded maximum value of {stop}")
+
+        return self.variables[index]
 
     def render(self, context: Any, template_text: Any) -> str:
         """

--- a/src/ibek/utils.py
+++ b/src/ibek/utils.py
@@ -62,7 +62,7 @@ class Utils:
         return self.variables.get(s_key, default)
 
     def incrementor(
-        self, name: str, start: int = 0, increment: int = 1, stop: int = 10000
+        self, name: str, start: int = 0, increment: int = 1, stop: int | None = None
     ) -> int:
         """
         get a named counter that increments by inc each time it is called
@@ -78,7 +78,7 @@ class Utils:
             if not isinstance(counter, int):
                 raise ValueError(f"Variable {index} is not an integer")
             self.variables[index] += increment
-            if self.variables[index] > stop:
+            if stop is not None and self.variables[index] > stop:
                 raise ValueError(f"Counter {index} exceeded maximum value of {stop}")
 
         return self.variables[index]

--- a/tests/samples/iocs/technosoft.ibek.ioc.yaml
+++ b/tests/samples/iocs/technosoft.ibek.ioc.yaml
@@ -29,7 +29,6 @@ entities:
     controllerName: TML
     P: "SPARC:TML"
     TTY: /tmp # /var/tmp/ttyV0
-    numAxes: 1
     hostid: 15
 
   - <<: *motor

--- a/tests/samples/outputs/technosoft/st.cmd
+++ b/tests/samples/outputs/technosoft/st.cmd
@@ -4,7 +4,7 @@ cd "/epics/ioc"
 dbLoadDatabase dbd/ioc.dbd
 ioc_registerRecordDeviceDriver pdbbase
 
-ndsCreateDevice "TechnosoftTML", "TML", "FILE=/tmp/,NAXIS=1,DEV_PATH=/tmp,HOST_ID=15,AXIS_SETUP_0=$(SUPPORT)/motorTechnosoft/tml_lib/config/star_vat_phs.t.zip,AXIS_ID_0=15,AXIS_HOMING_SW_0=LSN,AXIS_SETUP_1=$(SUPPORT)/motorTechnosoft/tml_lib/config/star_vat_phs.t.zip,AXIS_ID_1=17,AXIS_HOMING_SW_1=LSN"
+ndsCreateDevice "TechnosoftTML", "TML", "FILE=/tmp/,NAXIS=2,DEV_PATH=/tmp,HOST_ID=15,AXIS_SETUP_0=$(SUPPORT)/motorTechnosoft/tml_lib/config/star_vat_phs.t.zip,AXIS_ID_0=15,AXIS_HOMING_SW_0=LSN,AXIS_SETUP_1=$(SUPPORT)/motorTechnosoft/tml_lib/config/star_vat_phs.t.zip,AXIS_ID_1=17,AXIS_HOMING_SW_1=LSN"
 dbLoadRecords("$(SUPPORT)/motorTechnosoft/db/tmlAxis.template","PREFIX=SPARC:TML, CHANNEL_ID=MOT, CHANNEL_PREFIX=ax0, ASYN_PORT=TML, ASYN_ADDR=0, NSTEPS=200, NMICROSTEPS=256, VELO=20, VELO_MIN=0.1, VELO_MAX=50.0, ACCL=0.5, ACCL_MIN=0.01, ACCL_MAX=1.5, HAR=0.5, HVEL=10.0, JAR=1, JVEL=5, ENABLED=1, SLSP=0.8, EGU=ustep, TIMEOUT=0")
 dbLoadRecords("$(SUPPORT)/motorTechnosoft/db/tmlAxis.template","PREFIX=SPARC:TML, CHANNEL_ID=MOT, CHANNEL_PREFIX=ax1, ASYN_PORT=TML, ASYN_ADDR=0, NSTEPS=200, NMICROSTEPS=256, VELO=20, VELO_MIN=0.1, VELO_MAX=50.0, ACCL=0.5, ACCL_MIN=0.011, ACCL_MAX=1.5, HAR=0.5, HVEL=10.0, JAR=1, JVEL=5, ENABLED=1, SLSP=0.8, EGU=SPARC:TML, TIMEOUT=0")
 

--- a/tests/samples/schemas/fastVacuum.ibek.ioc.schema.json
+++ b/tests/samples/schemas/fastVacuum.ibek.ioc.schema.json
@@ -108,7 +108,7 @@
               "type": "integer"
             }
           ],
-          "default": "{{ _global.counter(master, start=1) }}",
+          "default": "{{ _global.incrementor(master, start=1) }}",
           "description": "union of <class 'int'> and jinja representation of {typ}",
           "title": "Gaugenum"
         },
@@ -119,7 +119,7 @@
           "type": "string"
         },
         "mask": {
-          "default": "{%- set m = \"mask_%s\" % master -%}\n{{ _global.set(m, _global.get(m, 0) + 2**gaugeNum) }}",
+          "default": "{{ _global.incrementor(\"mask_{}\".format(master), 2, 2**gaugeNum) }}",
           "description": "mask for the channel",
           "title": "Mask",
           "type": "string"
@@ -135,22 +135,6 @@
           "description": "Gauge PV",
           "title": "Gaugepv",
           "type": "string"
-        },
-        "addr_offset": {
-          "anyOf": [
-            {
-              "description": "jinja that renders to <class 'int'>",
-              "pattern": ".*\\{\\{.*\\}\\}.*",
-              "type": "string"
-            },
-            {
-              "description": "waveform address offset for the first waveform for this channel",
-              "type": "integer"
-            }
-          ],
-          "default": "{{ (gaugeNum - 1) * master.combined_nelm }}",
-          "description": "union of <class 'int'> and jinja representation of {typ}",
-          "title": "Addr Offset"
         }
       },
       "required": [

--- a/tests/samples/schemas/fastVacuum.ibek.ioc.schema.json
+++ b/tests/samples/schemas/fastVacuum.ibek.ioc.schema.json
@@ -108,7 +108,7 @@
               "type": "integer"
             }
           ],
-          "default": "{{ _global.counter(\"fvGaugeNum\", start=1) }}",
+          "default": "{{ _global.counter(master, start=1) }}",
           "description": "union of <class 'int'> and jinja representation of {typ}",
           "title": "Gaugenum"
         },
@@ -119,7 +119,7 @@
           "type": "string"
         },
         "mask": {
-          "default": "{{ _global.set('fvMask', _global.get('fvMask', 0) + 2**gaugeNum) }}",
+          "default": "{%- set m = \"mask_%s\" % master -%}\n{{ _global.set(m, _global.get(m, 0) + 2**gaugeNum) }}",
           "description": "mask for the channel",
           "title": "Mask",
           "type": "string"

--- a/tests/samples/schemas/ibek.support.schema.json
+++ b/tests/samples/schemas/ibek.support.schema.json
@@ -566,6 +566,7 @@
             {
               "type": "string"
             },
+            {},
             {
               "type": "null"
             }

--- a/tests/samples/schemas/ipac.ibek.ioc.schema.json
+++ b/tests/samples/schemas/ipac.ibek.ioc.schema.json
@@ -178,7 +178,7 @@
           "title": "Count"
         },
         "number": {
-          "default": "{{  _global.counter(\"InterruptVector\", start=192, stop=255, inc=count) }}",
+          "default": "{{  _global.incrementor(\"InterruptVector\", start=192, stop=255, increment=count) }}",
           "description": "Interrupt Vector number",
           "title": "Number",
           "type": "string"
@@ -537,7 +537,7 @@
           "title": "Interrupt Vector"
         },
         "card_id": {
-          "default": "{{ _global.counter(\"Carriers\", start=0) }}",
+          "default": "{{ _global.incrementor(\"Carriers\", start=0) }}",
           "description": "Carrier Card Identifier",
           "title": "Card Id",
           "type": "string"

--- a/tests/samples/schemas/technosoft.ibek.ioc.schema.json
+++ b/tests/samples/schemas/technosoft.ibek.ioc.schema.json
@@ -41,22 +41,6 @@
           "title": "Tty",
           "type": "string"
         },
-        "numAxes": {
-          "anyOf": [
-            {
-              "description": "jinja that renders to <class 'int'>",
-              "pattern": ".*\\{\\{.*\\}\\}.*",
-              "type": "string"
-            },
-            {
-              "description": "The number of axes to create",
-              "type": "integer"
-            }
-          ],
-          "default": 1,
-          "description": "union of <class 'int'> and jinja representation of {typ}",
-          "title": "Numaxes"
-        },
         "hostid": {
           "anyOf": [
             {
@@ -73,16 +57,27 @@
           "title": "Hostid"
         },
         "CONFIG": {
-          "default": "FILE=/tmp/,NAXIS={{numAxes}},DEV_PATH={{TTY}},HOST_ID={{hostid}}",
+          "default": "DEV_PATH={{TTY}},HOST_ID={{hostid}}",
           "description": "TML Configuration",
           "title": "Config",
           "type": "string"
         },
         "axisConfiguration": {
-          "default": "{{ _global.set_var('motorTML.axisConfiguration',[]) }}",
-          "description": "collects the axis configuration from axis entities",
-          "title": "Axisconfiguration",
-          "type": "string"
+          "anyOf": [
+            {
+              "description": "jinja that renders to <class 'list'>",
+              "pattern": ".*\\{\\{.*\\}\\}.*",
+              "type": "string"
+            },
+            {
+              "description": "collects the axis configuration from axis entities",
+              "items": {},
+              "type": "array"
+            }
+          ],
+          "default": [],
+          "description": "union of <class 'list'> and jinja representation of {typ}",
+          "title": "Axisconfiguration"
         }
       },
       "required": [
@@ -113,15 +108,25 @@
           "title": "Entity Enabled",
           "type": "boolean"
         },
-        "num": {
-          "default": "{{ _global.counter(\"motorTML.axisCount\", start=0) }}",
-          "description": "The auto incrementing axis number",
-          "title": "Num",
-          "type": "string"
-        },
         "controller": {
           "description": "a reference to the motion controller",
           "title": "Controller"
+        },
+        "num": {
+          "anyOf": [
+            {
+              "description": "jinja that renders to <class 'int'>",
+              "pattern": ".*\\{\\{.*\\}\\}.*",
+              "type": "string"
+            },
+            {
+              "description": "The axis number",
+              "type": "integer"
+            }
+          ],
+          "default": "{{ controller.axisConfiguration | length }}",
+          "description": "union of <class 'int'> and jinja representation of {typ}",
+          "title": "Num"
         },
         "CHANNEL_PREFIX": {
           "default": "ax0",
@@ -424,7 +429,7 @@
           "type": "string"
         },
         "axisConfiguration": {
-          "default": "{{ _global.get_var('motorTML.axisConfiguration').append(CONFIG) }}",
+          "default": "{{ controller.axisConfiguration.append(CONFIG) }}",
           "description": "Adds an axis configuration entry to the controller's list",
           "title": "Axisconfiguration",
           "type": "string"

--- a/tests/samples/schemas/technosoft.ibek.ioc.schema.json
+++ b/tests/samples/schemas/technosoft.ibek.ioc.schema.json
@@ -78,6 +78,12 @@
           "default": [],
           "description": "union of <class 'list'> and jinja representation of {typ}",
           "title": "Axisconfiguration"
+        },
+        "axisNum": {
+          "default": "{{ \"axes_{}\".format(controllerName) }}",
+          "description": "A name for the axis counter (used to generate unique axis numbers)",
+          "title": "Axisnum",
+          "type": "string"
         }
       },
       "required": [
@@ -124,7 +130,7 @@
               "type": "integer"
             }
           ],
-          "default": "{{ controller.axisConfiguration | length }}",
+          "default": "{{ _global.incrementor(controller.axisNum) }}",
           "description": "union of <class 'int'> and jinja representation of {typ}",
           "title": "Num"
         },

--- a/tests/samples/schemas/utils.ibek.ioc.schema.json
+++ b/tests/samples/schemas/utils.ibek.ioc.schema.json
@@ -24,13 +24,13 @@
           "type": "string"
         },
         "test_global_var": {
-          "default": "{{  _global.set_var(\"magic_global\", 42) }}",
+          "default": "{{  _global.set(\"magic_global\", 42) }}",
           "description": "test global variable setter",
           "title": "Test Global Var",
           "type": "string"
         },
         "get_global": {
-          "default": "{{  _global.get_var(\"magic_global\") }}",
+          "default": "{{  _global.get(\"magic_global\") }}",
           "description": "test global variable getter",
           "title": "Get Global",
           "type": "string"

--- a/tests/samples/support/epics.ibek.support.yaml
+++ b/tests/samples/support/epics.ibek.support.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=../schemas/bek.support.schema.json
+# yaml-language-server: $schema=../schemas/ibek.support.schema.json
 
 module: epics
 defs:
@@ -85,7 +85,7 @@ defs:
 
     post_defines:
       - name: number
-        value: '{{  _global.counter("InterruptVector", start=192, stop=255, inc=count) }}'
+        value: '{{  _global.incrementor("InterruptVector", start=192, stop=255, increment=count) }}'
         description: Interrupt Vector number
 
     env_vars:

--- a/tests/samples/support/fastVacuum.ibek.support.yaml
+++ b/tests/samples/support/fastVacuum.ibek.support.yaml
@@ -118,7 +118,7 @@ defs:
         name: gaugeNum
         type: int
         value: |-
-          {{ _global.counter(master, start=1) }}
+          {{ _global.incrementor(master, start=1) }}
 
       - description: fan number
         name: fan
@@ -127,9 +127,9 @@ defs:
 
       - description: mask for the channel
         name: mask
+        # incrementor takes name, start=0, increment=1, end=10000
         value: |-
-          {%- set m = "mask_%s" % master -%}
-          {{ _global.set(m, _global.get(m, 0) + 2**gaugeNum) }}
+          {{ _global.incrementor("mask_{}".format(master), 2, 2**gaugeNum) }}
 
       - description: link number
         name: lnk_no

--- a/tests/samples/support/fastVacuum.ibek.support.yaml
+++ b/tests/samples/support/fastVacuum.ibek.support.yaml
@@ -141,11 +141,8 @@ defs:
         value: |-
           {{ master.device }}:GAUGE:{{id}}_0
 
-      - description: waveform address offset for the first waveform for this channel
-        name: addr_offset
-        type: int
-        value: |-
-          {{ (gaugeNum - 1) * master.combined_nelm }}
+    shared:
+      - &wave_addr "{{ _global.incrementor('wave_addr_{}'.format(master), 0, master.waveform_nelm) }}"
 
     databases:
       - file: $(DLSPLC)/db/dlsPLC_fastVacuumLink.template
@@ -161,11 +158,11 @@ defs:
           id: "{{id}}"
           em:
           waveform_nelm: "{{master.waveform_nelm}}"
-          wave0_addr: "{{ addr_offset }}"
-          wave1_addr: "{{ addr_offset + master.waveform_nelm }}"
-          wave2_addr: "{{ addr_offset + master.waveform_nelm * 2 }}"
-          wave3_addr: "{{ addr_offset + master.waveform_nelm * 3 }}"
-          wave4_addr: "{{ addr_offset + master.waveform_nelm * 4 }}"
-          wave5_addr: "{{ addr_offset + master.waveform_nelm * 5 }}"
+          wave0_addr: *wave_addr
+          wave1_addr: *wave_addr
+          wave2_addr: *wave_addr
+          wave3_addr: *wave_addr
+          wave4_addr: *wave_addr
+          wave5_addr: *wave_addr
           combined_nelm: "{{master.combined_nelm}}"
           timeout:

--- a/tests/samples/support/fastVacuum.ibek.support.yaml
+++ b/tests/samples/support/fastVacuum.ibek.support.yaml
@@ -118,7 +118,7 @@ defs:
         name: gaugeNum
         type: int
         value: |-
-          {{ _global.counter("fvGaugeNum", start=1) }}
+          {{ _global.counter(master, start=1) }}
 
       - description: fan number
         name: fan
@@ -128,7 +128,8 @@ defs:
       - description: mask for the channel
         name: mask
         value: |-
-          {{ _global.set('fvMask', _global.get('fvMask', 0) + 2**gaugeNum) }}
+          {%- set m = "mask_%s" % master -%}
+          {{ _global.set(m, _global.get(m, 0) + 2**gaugeNum) }}
 
       - description: link number
         name: lnk_no

--- a/tests/samples/support/ipac.ibek.support.yaml
+++ b/tests/samples/support/ipac.ibek.support.yaml
@@ -36,7 +36,7 @@ defs:
 
     post_defines:
       - name: card_id
-        value: '{{ _global.counter("Carriers", start=0) }}'
+        value: '{{ _global.incrementor("Carriers", start=0) }}'
         description: Carrier Card Identifier
 
     pre_init:

--- a/tests/samples/support/technosoft.ibek.support.yaml
+++ b/tests/samples/support/technosoft.ibek.support.yaml
@@ -23,12 +23,6 @@ defs:
           TTY
 
       - type: int
-        name: numAxes
-        description: |-
-          The number of axes to create
-        default: 1
-
-      - type: int
         name: hostid
         description: |-
           Host ID
@@ -38,15 +32,17 @@ defs:
         description: |-
           TML Configuration
         default: |-
-          FILE=/tmp/,NAXIS={{numAxes}},DEV_PATH={{TTY}},HOST_ID={{hostid}}
+          DEV_PATH={{TTY}},HOST_ID={{hostid}}
+
     post_defines:
       - name: axisConfiguration
         description: collects the axis configuration from axis entities
-        value: |-
-          {{ _global.set_var('motorTML.axisConfiguration',[]) }}
+        type: list
+        value: []
+
     pre_init:
       - value: |
-          ndsCreateDevice "TechnosoftTML", "{{controllerName}}", "{{CONFIG}}{{"".join(_global.get_var('motorTML.axisConfiguration')) }}"
+          ndsCreateDevice "TechnosoftTML", "{{controllerName}}", "FILE=/tmp/,NAXIS={{axisConfiguration | length}},{{CONFIG}}{{"".join(axisConfiguration) }}"
 
   - name: motorAxis
     description: |-
@@ -57,6 +53,13 @@ defs:
         name: controller
         description: |-
           a reference to the motion controller
+
+      - type: int
+        name: num
+        description: |-
+          The axis number
+        default: |-
+          {{ controller.axisConfiguration | length }}
 
       - type: str
         name: CHANNEL_PREFIX
@@ -199,17 +202,11 @@ defs:
         default: |-
           ,AXIS_SETUP_{{num}}=$(SUPPORT)/motorTechnosoft/tml_lib/config/{{axconf}},AXIS_ID_{{num}}={{axid}},AXIS_HOMING_SW_{{num}}={{homing}}
 
-    pre_defines:
-      - name: num
-        description: The auto incrementing axis number
-        value: |-
-          {{ _global.counter("motorTML.axisCount", start=0) }}
-
     post_defines:
       - name: axisConfiguration
         description: Adds an axis configuration entry to the controller's list
         value: |-
-          {{ _global.get_var('motorTML.axisConfiguration').append(CONFIG) }}
+          {{ controller.axisConfiguration.append(CONFIG) }}
 
     pre_init:
       - value: |

--- a/tests/samples/support/technosoft.ibek.support.yaml
+++ b/tests/samples/support/technosoft.ibek.support.yaml
@@ -40,9 +40,17 @@ defs:
         type: list
         value: []
 
+      # this is not strictly required but it makes the jinja references in
+      # the motorAxis and controller's post_init sections easier to read
+      # as their association is far more obvious
+      - name: axisNum
+        description: A name for the axis counter (used to generate unique axis numbers)
+        value: |-
+          {{ "axes_{}".format(controllerName) }}
+
     pre_init:
       - value: |
-          ndsCreateDevice "TechnosoftTML", "{{controllerName}}", "FILE=/tmp/,NAXIS={{axisConfiguration | length}},{{CONFIG}}{{"".join(axisConfiguration) }}"
+          ndsCreateDevice "TechnosoftTML", "{{controllerName}}", "FILE=/tmp/,NAXIS={{_global.get(axisNum)+1}},{{CONFIG}}{{"".join(axisConfiguration) }}"
 
   - name: motorAxis
     description: |-
@@ -59,7 +67,7 @@ defs:
         description: |-
           The axis number
         default: |-
-          {{ controller.axisConfiguration | length }}
+          {{ _global.incrementor(controller.axisNum) }}
 
       - type: str
         name: CHANNEL_PREFIX

--- a/tests/samples/support/utils.ibek.support.yaml
+++ b/tests/samples/support/utils.ibek.support.yaml
@@ -17,22 +17,22 @@ defs:
     post_defines:
       - name: test_global_var
         description: test global variable setter
-        value: '{{  _global.set_var("magic_global", 42) }}'
+        value: '{{  _global.set("magic_global", 42) }}'
       - name: get_global
         description: test global variable getter
-        value: '{{  _global.get_var("magic_global") }}'
+        value: '{{  _global.get("magic_global") }}'
 
     env_vars:
       - name: "{{ name }}"
-        value: '{{  _global.counter("InterruptVector", start=192, stop=255) }}'
+        value: '{{  _global.incrementor("InterruptVector", start=192, stop=255) }}'
 
     pre_init:
       - type: comment
         value: global "magic" is {{ get_global }}
       - type: comment
-        value: counter "InterruptVector" is now {{ _global.counter("InterruptVector", start=192, stop=255) }}
+        value: counter "InterruptVector" is now {{ _global.incrementor("InterruptVector", start=192, stop=255) }}
       - type: comment
-        value: counter "InterruptVector" is now {{ _global.counter("InterruptVector", start=192, stop=255) }}
+        value: counter "InterruptVector" is now {{ _global.incrementor("InterruptVector", start=192, stop=255) }}
 
   - name: InterruptVectorVME2
     description: naughty second use of same counter
@@ -43,4 +43,4 @@ defs:
 
     env_vars:
       - name: "second_{{ name }}"
-        value: '{{  _global.counter("InterruptVector", start=193, stop=194) }}'
+        value: '{{  _global.incrementor("InterruptVector", start=193, stop=194) }}'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -128,8 +128,8 @@ def test_ipac(tmp_epics_root: Path, samples: Path):
     """
 
     # reset the InterruptVector counter to its initial state (if already used)
-    if "InterruptVector" in utils.UTILS.counters:
-        utils.UTILS.counters["InterruptVector"].current = 192
+    if "InterruptVector" in utils.UTILS.variables:
+        utils.UTILS.variables["InterruptVector"] = 191
 
     generic_generate(
         tmp_epics_root,

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -13,23 +13,6 @@ from ibek.utils import UTILS
 from tests.conftest import run_cli
 
 
-def test_counter_reuse(tmp_epics_root: Path, samples: Path):
-    """
-    Check you cannot redefine a counter with the same name and different params
-    """
-    UTILS.__reset__()
-
-    entity_file = samples / "iocs" / "bad_counter.ibek.ioc.yaml"
-    definition_file1 = samples / "support" / "utils.ibek.support.yaml"
-
-    with pytest.raises(ValueError) as ctx:
-        run_cli("runtime", "generate", entity_file, definition_file1)
-    assert (
-        str(ctx.value)
-        == "Redefining counter InterruptVector with different start/stop values"
-    )
-
-
 def test_counter_overuse(tmp_epics_root: Path, samples: Path):
     """
     Check that counter limits are enforced
@@ -42,7 +25,7 @@ def test_counter_overuse(tmp_epics_root: Path, samples: Path):
     with pytest.raises(ValueError) as ctx:
         run_cli("runtime", "generate", entity_file, definition_file1)
 
-    assert "Counter 195 exceeded stop value of 194" in str(ctx.value)
+    assert "Counter InterruptVector exceeded maximum value of 194" in str(ctx.value)
 
 
 def test_bad_ref(samples: Path):


### PR DESCRIPTION
A few more improvements to jinja
- object references are now true objects in jinja
- therefore e.g. motors can add to a list set up by their controller
- see  https://github.com/epics-containers/ibek/blob/d0fb244a9a4b8492915339b731a2f4993431fce5/tests/samples/support/technosoft.ibek.support.yaml#L213-L217
- the _global.counter feature has been renamed incrementor and always takes a increment value - thus allowing simplification of initialization and update of a variable
- eg. this value that accumulates in powers of 2 https://github.com/epics-containers/ibek/blob/d0fb244a9a4b8492915339b731a2f4993431fce5/tests/samples/support/fastVacuum.ibek.support.yaml#L128-L132
- also counters are included in the global variables and accessible via '_global.get' 
- e.g. axisNum here https://github.com/epics-containers/ibek/blob/d0fb244a9a4b8492915339b731a2f4993431fce5/tests/samples/support/technosoft.ibek.support.yaml#L37-L53