### PR TITLE
Add a new ibek function to expose stdio over a socket

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,7 @@
     },
     "features": {
         // add in eternal history and other bash features
-        "ghcr.io/diamondlightsource/devcontainer-features/bash-config:1.0.0": {}
+        "ghcr.io/diamondlightsource/devcontainer-features/bash-config:1": {}
     },
     // Create the config folder for the bash-config feature
     "initializeCommand": "mkdir -p ${localEnv:HOME}/.config/bash-config",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # The devcontainer should use the developer target and run as root with podman
 # or docker with user namespaces.
-ARG PYTHON_VERSION=3.11
+ARG PYTHON_VERSION=3.12
 FROM python:${PYTHON_VERSION} AS developer
 
 # Add any system dependencies for the developer/build environment here

--- a/src/ibek/runtime_cmds/commands.py
+++ b/src/ibek/runtime_cmds/commands.py
@@ -205,11 +205,7 @@ def expose_stdio(
 
 
 async def _expose_stdio_async(command: str) -> None:
-    # Check if the socket is already in use
     socket_path: Path = Path("/tmp") / "stdio.sock"
-    if socket_path.exists():
-        sys.stderr.write(f"Socket {socket_path} already exists. Exiting.\n")
-        raise typer.Exit()
 
     # Create the socket and bind it to the path
     server_socket = socket.socket(socket.AF_UNIX)


### PR DESCRIPTION
This is fully working with readline editing supplied by the IOC using raw mode in socat.
Ctrl C breaks the connection but leaves the IOC running and you can reconnect.

It's 200 lines of extra code - but in a package that we already install in all IOCs. I'm sure procserv can do the same job but I'm preferring this for now.

@coretl I'll let you make a call on procserv vs bespoke code in ibek.

