### PR TITLE
add system stdin monitoring

### DIFF
--- a/src/ibek/runtime_cmds/commands.py
+++ b/src/ibek/runtime_cmds/commands.py
@@ -249,8 +249,8 @@ async def _expose_stdio_async(command: str):
                 write_to_process(reader),
             )
         finally:
-            writer.close()
             clients.remove(writer)
+            writer.close()
             await writer.wait_closed()
             sys.stdout.write("Client disconnected from the socket.\n")
 


### PR DESCRIPTION
# purpose of this PR
@coretl we have a tiny niggle with this.

- IOCs that start with `ibek runtime expose-stdio` don't respond to stdin when connected to directly. 
- This is not really an issue on the cluster where we have ec to give us an entry point into socat.
- but for the local case these IOCs are a bit broken and there is no ec. We could `podman compose exec ioc-attach` I guess but that is not super discoverable
- this PR adds monitoring of stdin so that the IOC console behaves as before

Only it doesn't because the arrow keys don't work and line edit is broken.

I need the equivalent of socat's raw mode somehow - any ideas how to achieve that?

# other issues with expose-stdio
- no stdio in the main process means:
  - you can't just launch an IOC with podman and interact with it
  - consequently the ioc-template's built in CI does not work (it just hangs)  
- the solution as it stands does not work for python IOCs
- the solution as it stands does not work for RTEMS iocs (but that is easily fixed as RTEMS proxy does have ibek - its just another change to the start.sh)

# Issues with interdependence

The most obvious solution to this is to not use expose-stdio in normal launching of the IOC but override the entrypoint to use expose-stdio in the helm chart. I like this because it keeps the locally launched IOCs simple and unchanged.

However, this would be a breaking change and difficult to roll out because the helm chart version and the IOC version would have to match.

This puts the decision to use a common Chart.yml for all iocs in a service repository in a poor light. (I was discussing this with Joseph yesterday and it also causes funny behaviour in renovate - plus now we have renovate the need for sharing boilerplate between IOC instances seems much weaker)

Here we have a situation where [Helm Chart, ioc-template, ibek, epics-base(to install socat)] all need changing for a feature and there is no good way to make all these happen simultaneously. I want to think hard on this problem because it will come up again in future. Its all very well when the framework is stable - but what happens when we want to make changes that affect multiple parts and we have 1000s IOCs deployed?

The goal would be to be able to change each of the 4 parts in a backward compatible fashion so that you get the new feature once you have all the new parts but things still work (without the new feature) when you have some of them.