### PR TITLE
fix: deduplicate modules in extract-runtime-assets

### DIFF
--- a/src/ibek/ioc_cmds/assets.py
+++ b/src/ibek/ioc_cmds/assets.py
@@ -105,7 +105,7 @@ def extract_assets(
         binaries.extend(source.glob(f"*/*/{find}"))
         binaries.extend(source.glob(f"*/{find}"))
 
-    modules = [binary.parent for binary in binaries]
+    modules = list(dict.fromkeys(binary.parent for binary in binaries))
 
     destination.mkdir(exist_ok=True, parents=True)
     for module in modules:


### PR DESCRIPTION
Modules with symlinked db folders (e.g. opcua) were matched by multiple globs, causing the same symlink to be copied twice and triggering a SameFileError.