### PR TITLE
Allow IOC config folder to override pvi device files

### DIFF
--- a/src/ibek/runtime_cmds/commands.py
+++ b/src/ibek/runtime_cmds/commands.py
@@ -187,8 +187,39 @@ def do_generate(
         stream.write(db_txt)
 
 
+def find_pvi_device(rel_path: str, config_dir: Path) -> Path:
+    """Resolve a pvi device yaml file, allowing instance config overrides.
+
+    The IOC instance config folder can override a support module's pvi device
+    file by dropping in a file of the same name. Overrides are matched on file
+    name only (mirroring the autosave req file override convention), so a file
+    placed directly in the config folder wins over the one in PVI_DEFS.
+
+    Args:
+        rel_path: yaml_path from the entity pvi definition (already rendered),
+            absolute or relative to PVI_DEFS
+        config_dir: the IOC instance config folder to search for overrides
+
+    Returns:
+        Path to the pvi device yaml file to use
+
+    """
+    override = config_dir / Path(rel_path).name
+    if override.is_file():
+        return override
+    # No override: resolve relative to PVI_DEFS (absolute paths pass through),
+    # preserving support for relative sub-paths under PVI_DEFS.
+    return GLOBALS.PVI_DEFS / rel_path
+
+
 def generate_pvi(ioc: IOC) -> tuple[list[IndexEntry], list[tuple[Database, Entity]]]:
     """Generate pvi bob and template files to add to UI index and IOC database.
+
+    pvi device yaml files are normally read from PVI_DEFS, where they are
+    installed by support modules. A file of the same name dropped into the IOC
+    instance config folder overrides the one in PVI_DEFS (including when it is
+    referenced as a parent device file). This mirrors the autosave req file
+    override convention - see generate_autosave.
 
     Args:
         ioc: IOC instance to extract entity pvi definitions from
@@ -203,6 +234,12 @@ def generate_pvi(ioc: IOC) -> tuple[list[IndexEntry], list[tuple[Database, Entit
 
     formatter = DLSFormatter()
 
+    # The IOC instance config folder may supply pvi device yaml files that
+    # override those shipped in PVI_DEFS by support modules. An override matches
+    # on file name and also takes precedence when resolving parent device files.
+    config_dir = GLOBALS.IOC_FOLDER / GLOBALS.CONFIG_DIR_NAME
+    pvi_search_path = [config_dir, GLOBALS.PVI_DEFS]
+
     formatted_pvi_devices: list[str] = []
     for entity in ioc.entities:
         definition = entity._model
@@ -210,7 +247,8 @@ def generate_pvi(ioc: IOC) -> tuple[list[IndexEntry], list[tuple[Database, Entit
             continue
         entity_pvi = definition.pvi
 
-        pvi_yaml = GLOBALS.PVI_DEFS / UTILS.render(entity, entity_pvi.yaml_path)
+        rel_path = UTILS.render(entity, entity_pvi.yaml_path)
+        pvi_yaml = find_pvi_device(rel_path, config_dir)
         device_name = pvi_yaml.name.split(".")[0]
         device_bob = GLOBALS.OPI_OUTPUT / f"{device_name}.pvi.bob"
 
@@ -221,7 +259,7 @@ def generate_pvi(ioc: IOC) -> tuple[list[IndexEntry], list[tuple[Database, Entit
             or entity_pvi.ui_index
         ):
             device = Device.deserialize(pvi_yaml)
-            device.deserialize_parents([GLOBALS.PVI_DEFS])
+            device.deserialize_parents(pvi_search_path)
 
             if entity_pvi.pv:
                 # Create a template with the V4 structure defining a PVI interface

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,8 @@ from typer.testing import CliRunner
 
 import ibek.utils as utils
 from ibek import __version__
-from ibek.runtime_cmds.commands import do_generate
+from ibek.globals import GLOBALS
+from ibek.runtime_cmds.commands import do_generate, find_pvi_device
 from tests.conftest import run_cli
 
 runner = CliRunner()
@@ -169,6 +170,63 @@ def generic_generate(
             actual = epics_root / "opi" / output.name
         assert actual.exists(), f"Missing output file {actual}"
         assert output.read_text().strip() == actual.read_text().strip()
+
+
+def test_find_pvi_device(tmp_epics_root: Path):
+    """
+    find_pvi_device resolves against PVI_DEFS, but a file of the same name
+    dropped into the IOC instance config folder overrides it.
+    """
+    config_dir = GLOBALS.IOC_FOLDER / GLOBALS.CONFIG_DIR_NAME
+
+    # with no override the file resolves relative to PVI_DEFS
+    assert find_pvi_device("simple.pvi.device.yaml", config_dir) == (
+        GLOBALS.PVI_DEFS / "simple.pvi.device.yaml"
+    )
+
+    # a relative sub-path with no override is preserved under PVI_DEFS
+    assert find_pvi_device("sub/simple.pvi.device.yaml", config_dir) == (
+        GLOBALS.PVI_DEFS / "sub" / "simple.pvi.device.yaml"
+    )
+
+    # dropping a file of the same name in the config folder overrides it,
+    # matching on file name only
+    override = config_dir / "simple.pvi.device.yaml"
+    override.write_text("label: Overridden Device\n")
+    assert find_pvi_device("simple.pvi.device.yaml", config_dir) == override
+    assert find_pvi_device("sub/simple.pvi.device.yaml", config_dir) == override
+
+
+def test_pvi_config_override(tmp_epics_root: Path, samples: Path):
+    """
+    A pvi device yaml dropped into the IOC instance config folder overrides the
+    one shipped in PVI_DEFS by a support module.
+    """
+    config_dir = GLOBALS.IOC_FOLDER / GLOBALS.CONFIG_DIR_NAME
+    (config_dir / "simple.pvi.device.yaml").write_text(
+        "label: Overridden Device\n"
+        "children:\n"
+        "  - type: SignalR\n"
+        "    name: SimplePV\n"
+        "    read_pv: $(P)Simple\n"
+        "    read_widget:\n"
+        "      type: TextRead\n"
+    )
+
+    with pytest.deprecated_call():
+        do_generate(
+            [samples / "iocs" / "motorSim.ibek.ioc.yaml"],
+            [
+                samples / "support" / f"{name}.ibek.support.yaml"
+                for name in ["motorSim", "asyn"]
+            ],
+            tmp_epics_root / "runtime",
+            pvi=True,
+        )
+
+    bob = (GLOBALS.OPI_OUTPUT / "simple.pvi.bob").read_text()
+    assert "Overridden Device" in bob
+    assert "Simple Device" not in bob
 
 
 def test_andreas_motors(tmp_epics_root: Path, samples: Path):


### PR DESCRIPTION
## Summary

pvi device yaml files are currently read only from `PVI_DEFS` (`/epics/pvi-defs`), where support modules install them, with no way to override them per IOC instance. Autosave `.req` files, by contrast, can already be overridden by dropping a file into the IOC instance config folder (`link_req_files()` in `autosave.py`).

This PR extends that same drop-in override convention to pvi device files.

## Behaviour

- A `*.pvi.device.yaml` of the same name placed in the IOC instance config folder now takes precedence over the one in `PVI_DEFS`.
- Overrides are matched on **file name** only — the same convention used for autosave `.req` files.
- The override also wins when resolving **parent** device files: `deserialize_parents` is now given `[config_dir, PVI_DEFS]` as its search path, and pvi's `find_pvi_yaml` returns the first match.
- No new staging folder, symlinks, or build-time step are required — `generate_pvi` reads each device yaml directly by path, so this is a straight lookup-with-fallback.

## Implementation

- New `find_pvi_device(rel_path, config_dir)` helper resolves the device yaml: config folder (by name) wins, otherwise it falls back to `PVI_DEFS / rel_path` (preserving relative sub-paths and absolute paths as before).
- `generate_pvi` uses the helper for the device file and passes `[config_dir, PVI_DEFS]` to `deserialize_parents`.
- Docstring on `generate_pvi` documents the convention, cross-referencing `generate_autosave`.

## Tests

- `test_find_pvi_device` — unit test of the resolution logic (no override, relative sub-path, override by name).
- `test_pvi_config_override` — end-to-end `do_generate` run asserting a device yaml dropped into the config folder changes the generated `simple.pvi.bob`.

Full existing suite (`test_cli`, `test_repeat`, `test_runtime`, `test_do_wait`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced PVI device configuration management with instance-level overrides: place custom YAML files in your IOC configuration directory to override PVI device definitions, with automatic fallback to shipped definitions when overrides are absent.

* **Tests**
  * Added tests verifying PVI device path resolution and instance-level override functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->