### PR TITLE
test: verify config folder overrides pvi parent device files

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -229,6 +229,44 @@ def test_pvi_config_override(tmp_epics_root: Path, samples: Path):
     assert "Simple Device" not in bob
 
 
+def test_pvi_config_override_parent(tmp_epics_root: Path, samples: Path):
+    """
+    A pvi device yaml in the IOC instance config folder also overrides a device
+    that is referenced as a *parent* of another device. Here the quadem IOC
+    generates NDPluginStats, whose parent is NDPluginDriver; overriding
+    NDPluginDriver in the config folder changes the generated NDPluginStats bob.
+    """
+    config_dir = GLOBALS.IOC_FOLDER / GLOBALS.CONFIG_DIR_NAME
+    # an override parent device with a single, uniquely named signal
+    (config_dir / "NDPluginDriver.pvi.device.yaml").write_text(
+        "label: NDPluginDriver\n"
+        "parent: asynNDArrayDriver\n"
+        "children:\n"
+        "  - type: SignalR\n"
+        "    name: OverriddenParentSignal\n"
+        "    read_pv: $(P)$(R)OverriddenParentSignal_RBV\n"
+        "    read_widget:\n"
+        "      type: TextRead\n"
+    )
+
+    with pytest.deprecated_call():
+        do_generate(
+            [samples / "iocs" / "quadem.ibek.ioc.yaml"],
+            [
+                samples / "support" / f"{name}.ibek.support.yaml"
+                for name in ["ADCore", "quadem"]
+            ],
+            tmp_epics_root / "runtime",
+            pvi=True,
+        )
+
+    bob = (GLOBALS.OPI_OUTPUT / "NDPluginStats.pvi.bob").read_text()
+    # the overridden parent's signal is present...
+    assert "OverriddenParentSignal" in bob
+    # ...and signals only present in the original PVI_DEFS parent are gone
+    assert "EnableCallbacks" not in bob
+
+
 def test_andreas_motors(tmp_epics_root: Path, samples: Path):
     """
     Motor and axis example


### PR DESCRIPTION
## Summary

Follow-up to #351 (now merged), which added the ability to override pvi device files by dropping a file into the IOC instance config folder.

#351 wired `deserialize_parents` to search the config folder ahead of `PVI_DEFS`, so overrides also apply when a device is referenced as a **parent** of another device. However, the only test added there exercised the direct-device override path — the parent path was covered by reasoning about pvi's `find_pvi_yaml` ordering, not by a test. This PR closes that gap.

## Test

`test_pvi_config_override_parent`:
- The quadem IOC generates `NDPluginStats`, whose pvi device declares `parent: NDPluginDriver`.
- An override `NDPluginDriver.pvi.device.yaml` (with a uniquely named `OverriddenParentSignal`) is dropped into the config folder.
- After `do_generate(..., pvi=True)`, the generated `NDPluginStats.pvi.bob` is asserted to contain `OverriddenParentSignal` and **not** `EnableCallbacks` (a signal present only in the original `PVI_DEFS` parent) — proving the parent was resolved from the config folder, not `PVI_DEFS`.

Verified meaningful: the un-overridden quadem output normally contains `EnableCallbacks`. Full `test_cli` / `test_repeat` / `test_runtime` suites pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added system test to verify PVI device YAML configuration overrides correctly apply to parent device references in generated IOC configurations, ensuring override functionality works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->