### PR TITLE
Add `ibek pattern` runtime-support vendoring (keystone)

### DIFF
--- a/src/ibek/__main__.py
+++ b/src/ibek/__main__.py
@@ -5,6 +5,7 @@ from ibek._version import __version__
 from ibek.dev_cmds.commands import dev_cli
 from ibek.globals import NaturalOrderGroup
 from ibek.ioc_cmds.commands import ioc_cli
+from ibek.pattern_cmds.commands import pattern_cli
 from ibek.runtime_cmds.commands import runtime_cli
 from ibek.support_cmds.commands import support_cli
 
@@ -29,6 +30,11 @@ cli.add_typer(
     dev_cli,
     name="dev",
     help="Commands for working inside Generic IOC development containers",
+)
+cli.add_typer(
+    pattern_cli,
+    name="pattern",
+    help="Commands for vendoring runtime-support patterns into a services repo",
 )
 
 yaml = YAML()

--- a/src/ibek/globals.py
+++ b/src/ibek/globals.py
@@ -69,6 +69,19 @@ class _Globals:
         return self._EPICS_ROOT / "autosave"
 
     @property
+    def RUNTIME_PROTOCOL(self):
+        """Directory of streamDevice protocol files placed for IOC boot.
+
+        This is the directory that STREAM_PROTOCOL_PATH points at by convention.
+        """
+        return self.RUNTIME_OUTPUT / "protocol"
+
+    @property
+    def RUNTIME_DB(self):
+        """Directory of instance db/template files placed for IOC boot."""
+        return self.RUNTIME_OUTPUT / "db"
+
+    @property
     def EPICS_BASE(self):
         """The folder containing the epics base source and binaries"""
         return self._EPICS_ROOT / "epics-base"
@@ -101,6 +114,11 @@ TEMPLATES = Path(__file__).parent / "templates"
 SUPPORT_YAML_PATTERN = "*ibek.support.yaml"
 PVI_YAML_PATTERN = "*pvi.device.yaml"
 AUTOSAVE_PATTERN = "*.req"
+
+# Runtime-support vendoring (ibek pattern) artifacts. These live at the IOC
+# instance root (NOT in config/, which is the K8s ConfigMap, runtime inputs only).
+RUNTIME_LOCK_NAME = "runtime-lock.yaml"
+IOC_SCHEMA_NAME = "ioc.schema.json"
 
 GLOBALS = _Globals()
 

--- a/src/ibek/pattern_cmds/commands.py
+++ b/src/ibek/pattern_cmds/commands.py
@@ -1,0 +1,146 @@
+"""
+``ibek pattern`` — vendor runtime-support patterns into a services repo.
+
+Patterns (StreamDevice device support, AreaDetector plugin sets, ...) are copied
+from a central library into an IOC instance at a pinned version, recorded in a
+``runtime-lock.yaml`` with per-file SHA-256 integrity hashes. This restores a
+per-instance version axis independent of the image, and makes "what is this IOC
+running?" answerable from the committed lock with cryptographic certainty.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from ibek.globals import NaturalOrderGroup
+
+from . import vendor
+from .schema import generate_instance_schema
+from .sources import PatternError
+
+log = logging.getLogger(__name__)
+pattern_cli = typer.Typer(cls=NaturalOrderGroup)
+
+InstanceArg = Annotated[
+    Path,
+    typer.Argument(
+        help="The IOC instance folder (containing config/)",
+        exists=True,
+        dir_okay=True,
+        file_okay=False,
+        autocompletion=lambda: [],
+        resolve_path=True,
+    ),
+]
+
+SourceOpt = Annotated[
+    str | None,
+    typer.Option(
+        "--source",
+        "-s",
+        help="Override the library source URI (git URL or local path)",
+    ),
+]
+
+
+def _fail(exc: Exception) -> None:
+    log.error(str(exc))
+    raise typer.Exit(1) from exc
+
+
+@pattern_cli.command()
+def add(
+    name: Annotated[
+        str,
+        typer.Argument(
+            help="Pattern reference: [library:]name[@version], "
+            "e.g. ibek-runtime-streamdevice:lakeshore340@1.0.0",
+        ),
+    ],
+    instance: InstanceArg = Path("."),
+    source: SourceOpt = None,
+):
+    """Vendor a pattern into an instance, writing files + runtime-lock.yaml + schema."""
+    try:
+        vendor.add(name, instance, source_override=source)
+    except PatternError as exc:
+        _fail(exc)
+    typer.echo(f"vendored {name} into {instance}")
+
+
+@pattern_cli.command()
+def update(
+    name: Annotated[
+        str | None,
+        typer.Argument(help="Pattern name to update (default: all in the lock)"),
+    ] = None,
+    instance: InstanceArg = Path("."),
+    version: Annotated[
+        str | None,
+        typer.Option("--version", "-v", help="New pinned version to vendor"),
+    ] = None,
+    source: SourceOpt = None,
+):
+    """Re-vendor a pattern to a new pinned version; refresh hashes + schema."""
+    try:
+        vendor.update(name, instance, version=version, source_override=source)
+    except PatternError as exc:
+        _fail(exc)
+    typer.echo(f"updated {name or 'all patterns'} in {instance}")
+
+
+@pattern_cli.command()
+def check(
+    instance: InstanceArg = Path("."),
+    allow_dirty: Annotated[
+        bool,
+        typer.Option(
+            "--allow-dirty",
+            help="Downgrade hash mismatches to warnings "
+            "(also enabled by IBEK_ALLOW_DIRTY=1)",
+        ),
+    ] = False,
+):
+    """Verify vendored files match runtime-lock.yaml (vendor integrity)."""
+    allow = allow_dirty or os.getenv("IBEK_ALLOW_DIRTY") == "1"
+    result = vendor.check(instance, allow_dirty=allow)
+    for warning in result.warnings:
+        typer.echo(f"warning: {warning}")
+    for failure in result.failures:
+        typer.echo(f"error: {failure}", err=True)
+    if not result.ok:
+        raise typer.Exit(1)
+    typer.echo(f"{instance}: vendored files match the lock")
+
+
+@pattern_cli.command()
+def restore(
+    name: Annotated[
+        str | None,
+        typer.Argument(help="Pattern name to restore (default: all in the lock)"),
+    ] = None,
+    instance: InstanceArg = Path("."),
+):
+    """Revert vendored files to the version pinned in runtime-lock.yaml."""
+    try:
+        vendor.restore(name, instance)
+    except PatternError as exc:
+        _fail(exc)
+    typer.echo(f"restored {name or 'all patterns'} in {instance}")
+
+
+@pattern_cli.command()
+def schema(
+    instance: InstanceArg = Path("."),
+):
+    """Generate the instance's ioc.schema.json and rewrite ioc.yaml's header.
+
+    Fetches the published base schema for the instance's pinned image and merges
+    the instance's vendored / local support entities into it.
+    """
+    generate_instance_schema(instance)

--- a/src/ibek/pattern_cmds/lock.py
+++ b/src/ibek/pattern_cmds/lock.py
@@ -23,8 +23,9 @@ from ibek.globals import BaseSettings
 # format a pattern currently carries (yaml / proto / template / db / req).
 VENDOR_HEADER_TEMPLATE = "{comment} Vendored from {source}@{version} — DO NOT EDIT"
 
-# Map a file suffix to its line-comment prefix. ``#`` is the default and covers
-# all current pattern file types; extend here when a comment-less format appears.
+# Map a file suffix to its line-comment prefix. ``#`` is the default and is
+# correct for every pattern file type today; add an entry here only for a future
+# format whose line comment is not ``#``.
 COMMENT_PREFIXES: dict[str, str] = {
     ".proto": "#",
     ".protocol": "#",
@@ -43,20 +44,19 @@ DEFAULT_COMMENT_PREFIX = "#"
 DIRTY_MARKER = "DIRTY"
 
 
-def comment_prefix(path: Path) -> str | None:
-    """Return the line-comment prefix for ``path``, or None if comment-less.
+def comment_prefix(path: Path) -> str:
+    """Return the line-comment prefix for ``path``.
 
-    A None result means no header can be injected for this file type; the file
-    is still vendored and hashed, just without a provenance header.
+    ``#`` is correct for every format a pattern currently carries (yaml / proto
+    / template / db / req / cmd) and is the fallback for any other suffix, so a
+    provenance header can always be injected.
     """
     return COMMENT_PREFIXES.get(path.suffix, DEFAULT_COMMENT_PREFIX)
 
 
-def vendored_header(path: Path, source: str, version: str) -> str | None:
+def vendored_header(path: Path, source: str, version: str) -> str:
     """Build the deterministic vendored header line for ``path``."""
     prefix = comment_prefix(path)
-    if prefix is None:
-        return None
     return VENDOR_HEADER_TEMPLATE.format(comment=prefix, source=source, version=version)
 
 
@@ -67,8 +67,6 @@ def stamp_content(rel_path: Path, content: bytes, source: str, version: str) -> 
     (no header upstream) follows unchanged. Returns the exact bytes to write.
     """
     header = vendored_header(rel_path, source, version)
-    if header is None:
-        return content
     return (header + "\n").encode() + content
 
 

--- a/src/ibek/pattern_cmds/lock.py
+++ b/src/ibek/pattern_cmds/lock.py
@@ -1,0 +1,132 @@
+"""
+The ``runtime-lock.yaml`` integrity lock for vendored runtime-support patterns.
+
+A pattern is an arbitrary file-set (``*.ibek.support.yaml`` plus optional
+proto / template / db / req / ...) vendored from a central library at a pinned
+version. ``ibek pattern`` injects a deterministic ``# Vendored from ...`` header
+into each file *before* hashing, so the recorded SHA-256 covers the file exactly
+as written to disk and ``ibek pattern check`` is a trivial ``sha256(file) == lock``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from io import StringIO
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+from ibek.globals import BaseSettings
+
+# The deterministic vendored-file header. No timestamps or absolute paths so the
+# header (and therefore the hash) is reproducible. ``#`` is a comment in every
+# format a pattern currently carries (yaml / proto / template / db / req).
+VENDOR_HEADER_TEMPLATE = "{comment} Vendored from {source}@{version} — DO NOT EDIT"
+
+# Map a file suffix to its line-comment prefix. ``#`` is the default and covers
+# all current pattern file types; extend here when a comment-less format appears.
+COMMENT_PREFIXES: dict[str, str] = {
+    ".proto": "#",
+    ".protocol": "#",
+    ".template": "#",
+    ".substitutions": "#",
+    ".db": "#",
+    ".req": "#",
+    ".yaml": "#",
+    ".yml": "#",
+    ".cmd": "#",
+}
+DEFAULT_COMMENT_PREFIX = "#"
+
+# A lock entry whose hash is replaced by a string starting with this marker is a
+# deliberately, visibly dirty file (e.g. testing a fix against real hardware).
+DIRTY_MARKER = "DIRTY"
+
+
+def comment_prefix(path: Path) -> str | None:
+    """Return the line-comment prefix for ``path``, or None if comment-less.
+
+    A None result means no header can be injected for this file type; the file
+    is still vendored and hashed, just without a provenance header.
+    """
+    return COMMENT_PREFIXES.get(path.suffix, DEFAULT_COMMENT_PREFIX)
+
+
+def vendored_header(path: Path, source: str, version: str) -> str | None:
+    """Build the deterministic vendored header line for ``path``."""
+    prefix = comment_prefix(path)
+    if prefix is None:
+        return None
+    return VENDOR_HEADER_TEMPLATE.format(comment=prefix, source=source, version=version)
+
+
+def stamp_content(rel_path: Path, content: bytes, source: str, version: str) -> bytes:
+    """Inject the vendored header at the top of ``content`` (idempotent shape).
+
+    The header is prepended as the first line; the original pristine content
+    (no header upstream) follows unchanged. Returns the exact bytes to write.
+    """
+    header = vendored_header(rel_path, source, version)
+    if header is None:
+        return content
+    return (header + "\n").encode() + content
+
+
+def file_hash(data: bytes) -> str:
+    """Return the ``sha256:<hex>`` digest of ``data``."""
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def is_dirty(value: str) -> bool:
+    """True if a lock file-entry value is a deliberate DIRTY marker."""
+    return value.strip().startswith(DIRTY_MARKER)
+
+
+class PatternEntry(BaseSettings):
+    """One vendored pattern's lock record."""
+
+    version: str
+    source: str
+    files: dict[str, str]
+
+
+class RuntimeLock:
+    """Read/modify/write a ``runtime-lock.yaml`` at an IOC instance root."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self.patterns: dict[str, PatternEntry] = {}
+        if path.exists():
+            self.load()
+
+    def load(self) -> None:
+        raw = YAML(typ="safe").load(self.path) or {}
+        self.patterns = {name: PatternEntry(**entry) for name, entry in raw.items()}
+
+    def set_pattern(
+        self, name: str, version: str, source: str, files: dict[str, str]
+    ) -> None:
+        self.patterns[name] = PatternEntry(version=version, source=source, files=files)
+
+    def remove_pattern(self, name: str) -> None:
+        self.patterns.pop(name, None)
+
+    def save(self) -> None:
+        data = {
+            name: {
+                "version": entry.version,
+                "source": entry.source,
+                "files": dict(entry.files),
+            }
+            for name, entry in self.patterns.items()
+        }
+        yaml = YAML()
+        yaml.default_flow_style = False
+        if not data:
+            # An empty lock is removed rather than left as an empty document.
+            if self.path.exists():
+                self.path.unlink()
+            return
+        stream = StringIO()
+        yaml.dump(data, stream)
+        self.path.write_text(stream.getvalue())

--- a/src/ibek/pattern_cmds/lock.py
+++ b/src/ibek/pattern_cmds/lock.py
@@ -122,6 +122,8 @@ class RuntimeLock:
         }
         yaml = YAML()
         yaml.default_flow_style = False
+        # Keep each "<file>: sha256:<hex>" on one line (do not wrap long hashes).
+        yaml.width = 4096
         if not data:
             # An empty lock is removed rather than left as an empty document.
             if self.path.exists():

--- a/src/ibek/pattern_cmds/schema.py
+++ b/src/ibek/pattern_cmds/schema.py
@@ -174,11 +174,15 @@ def merge_entities(base: dict, support_yamls: list[Path]) -> dict:
             needed.add(ref)
             queue.append(ref)
 
-    for name in needed:
+    # Copy and extend in sorted order so the produced schema is byte-stable
+    # across runs (set/closure iteration order is otherwise non-deterministic,
+    # which would make the CI/pre-commit schema-freshness diff fail spuriously).
+    for name in sorted(needed):
         if name in extra_defs and name not in base_defs:
             base_defs[name] = extra_defs[name]
 
-    for disc, key in new_entities.items():
+    for disc in sorted(new_entities):
+        key = new_entities[disc]
         base_union["oneOf"].append({"$ref": f"#/$defs/{key}"})
         base_mapping[disc] = f"#/$defs/{key}"
 

--- a/src/ibek/pattern_cmds/schema.py
+++ b/src/ibek/pattern_cmds/schema.py
@@ -1,0 +1,259 @@
+"""
+Per-instance ``ioc.schema.json`` generation for IOC instances.
+
+The schema for an instance is *self-contained*: ibek fetches the published base
+schema for the instance's pinned image and programmatically merges the instance's
+vendored / local support entities into the discriminated ``oneOf`` /
+``discriminator.mapping`` / ``$defs``. The same function backs ``ibek pattern``,
+pre-commit and CI.
+
+If no published schema can be found for the instance's image, this is reported
+and the schema is left untouched (not an error) — generic images that have not
+published a schema release simply do not get editor validation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+from ibek.entity_factory import EntityFactory
+from ibek.globals import IOC_SCHEMA_NAME
+from ibek.ioc_factory import IocFactory
+
+# Entity defs always present in a generated base schema; never re-copied on merge.
+BUILTIN_DEFS = {"RepeatEntity", "Wait4IPEntity", "Wait4USBEntity"}
+
+PUBLISHED_SCHEMA_ASSET = "ibek.ioc.schema.json"
+SCHEMA_HEADER = f"# yaml-language-server: $schema=../{IOC_SCHEMA_NAME}"
+
+
+class SchemaNotFoundError(Exception):
+    """The published base schema for an image could not be located."""
+
+
+# --------------------------------------------------------------------------- #
+# image ref -> published release asset
+# --------------------------------------------------------------------------- #
+def resolve_image_ref(image: str) -> tuple[str, str, str]:
+    """Map a container image ref to ``(org, repo, tag)``.
+
+    ``ghcr.io/epics-containers/ioc-adsimdetector-runtime:2025.11.1`` ->
+    ``("epics-containers", "ioc-adsimdetector", "2025.11.1")``.
+    """
+    ref = re.sub(r"^[a-z0-9.-]+/", "", image.strip())  # strip registry host
+    repo_path, _, tag = ref.partition(":")
+    if not tag:
+        raise SchemaNotFoundError(f"image {image!r} has no tag")
+    parts = repo_path.split("/")
+    if len(parts) < 2:
+        raise SchemaNotFoundError(f"cannot parse org/repo from image {image!r}")
+    org, name = parts[0], parts[-1]
+    # Strip the developer/runtime suffix and optional architecture infix.
+    name = re.sub(r"(-rtems-beatnik)?(-developer|-runtime)$", "", name)
+    return org, name, tag
+
+
+def published_schema_url(image: str) -> str:
+    """Build the GitHub release-asset URL for an image's published schema."""
+    org, repo, tag = resolve_image_ref(image)
+    return (
+        f"https://github.com/{org}/{repo}/releases/download/{tag}/"
+        f"{PUBLISHED_SCHEMA_ASSET}"
+    )
+
+
+def _cache_path(image: str) -> Path:
+    org, repo, tag = resolve_image_ref(image)
+    root = Path(
+        os.getenv("IBEK_SCHEMA_CACHE", Path.home() / ".cache" / "ibek" / "schemas")
+    )
+    return root / f"{org}__{repo}__{tag}.json"
+
+
+def _http_get(url: str) -> bytes:
+    """Fetch ``url``; raise SchemaNotFound on any failure (monkeypatched in tests)."""
+    try:
+        with urllib.request.urlopen(url, timeout=30) as response:  # noqa: S310
+            return response.read()
+    except (urllib.error.URLError, OSError) as exc:
+        raise SchemaNotFoundError(f"could not fetch {url}: {exc}") from exc
+
+
+def fetch_base_schema(image: str) -> dict:
+    """Return the published base schema for ``image`` (cached per immutable tag)."""
+    cache = _cache_path(image)
+    if cache.exists():
+        return json.loads(cache.read_text())
+    url = published_schema_url(image)
+    data = _http_get(url)
+    try:
+        schema = json.loads(data)
+    except json.JSONDecodeError as exc:
+        raise SchemaNotFoundError(f"{url} did not return JSON: {exc}") from exc
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps(schema, indent=2))
+    return schema
+
+
+# --------------------------------------------------------------------------- #
+# entity merge
+# --------------------------------------------------------------------------- #
+def generate_schema_dict(support_yamls: list[Path]) -> dict:
+    """Generate the ibek IOC JSON schema for exactly ``support_yamls``."""
+    entity_factory = EntityFactory()
+    entity_models = entity_factory.make_entity_models(list(support_yamls))
+    ioc_model = IocFactory().make_ioc_model(entity_models)
+    return ioc_model.model_json_schema()
+
+
+def _union_node(schema: dict) -> dict:
+    """Return the discriminated-union node (handles inline and wrapper layouts)."""
+    items = schema["properties"]["entities"]["items"]
+    if "$ref" in items:
+        ref = items["$ref"].split("/")[-1]
+        return schema["$defs"][ref]
+    return items
+
+
+def _collect_refs(node: object, acc: set[str]) -> None:
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "$ref" and isinstance(value, str) and "/$defs/" in value:
+                acc.add(value.split("/")[-1])
+            else:
+                _collect_refs(value, acc)
+    elif isinstance(node, list):
+        for item in node:
+            _collect_refs(item, acc)
+
+
+def merge_entities(base: dict, support_yamls: list[Path]) -> dict:
+    """Merge the entities defined by ``support_yamls`` into ``base`` in place.
+
+    The extra entities (and the transitive closure of ``$defs`` they reference)
+    are grafted into the base schema's ``oneOf`` / ``discriminator.mapping`` /
+    ``$defs``. Built-ins and defs already present in the base are not duplicated.
+    """
+    if not support_yamls:
+        return base
+
+    extra = generate_schema_dict(support_yamls)
+    base_union = _union_node(base)
+    extra_union = _union_node(extra)
+    base_defs = base.setdefault("$defs", {})
+    extra_defs = extra.get("$defs", {})
+    base_mapping = base_union["discriminator"]["mapping"]
+
+    # New top-level entity types: in the extras' mapping, not built-in, not in base.
+    new_entities = {
+        disc: ref.split("/")[-1]
+        for disc, ref in extra_union["discriminator"]["mapping"].items()
+        if ref.split("/")[-1] not in BUILTIN_DEFS and disc not in base_mapping
+    }
+
+    # Transitive closure of $defs to copy (enums, nested entities, ...).
+    needed: set[str] = set(new_entities.values())
+    queue = list(needed)
+    while queue:
+        name = queue.pop()
+        definition = extra_defs.get(name)
+        if definition is None:
+            continue
+        refs: set[str] = set()
+        _collect_refs(definition, refs)
+        for ref in refs:
+            if ref in BUILTIN_DEFS or ref in base_defs or ref in needed:
+                continue
+            needed.add(ref)
+            queue.append(ref)
+
+    for name in needed:
+        if name in extra_defs and name not in base_defs:
+            base_defs[name] = extra_defs[name]
+
+    for disc, key in new_entities.items():
+        base_union["oneOf"].append({"$ref": f"#/$defs/{key}"})
+        base_mapping[disc] = f"#/$defs/{key}"
+
+    return base
+
+
+# --------------------------------------------------------------------------- #
+# instance schema
+# --------------------------------------------------------------------------- #
+def find_image(instance_dir: Path) -> str | None:
+    """Find the IOC image ref in an instance's ``values.yaml``."""
+    values = instance_dir / "values.yaml"
+    if not values.exists():
+        return None
+    data = YAML(typ="safe").load(values) or {}
+
+    found: list[str] = []
+
+    def walk(node: object) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key == "image" and isinstance(value, str):
+                    found.append(value)
+                else:
+                    walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(data)
+    for image in found:
+        if "/" in image and ":" in image and "REPLACE" not in image.upper():
+            return image
+    return None
+
+
+def rewrite_ioc_yaml_header(ioc_yaml: Path) -> None:
+    """Set ``ioc.yaml``'s first line to the sibling-schema language-server header."""
+    if not ioc_yaml.exists():
+        return
+    lines = ioc_yaml.read_text().splitlines()
+    if lines and lines[0].startswith("# yaml-language-server:"):
+        lines[0] = SCHEMA_HEADER
+    else:
+        lines.insert(0, SCHEMA_HEADER)
+    ioc_yaml.write_text("\n".join(lines) + "\n")
+
+
+def generate_instance_schema(instance_dir: Path) -> bool:
+    """Generate ``<instance>/ioc.schema.json`` and rewrite the ``ioc.yaml`` header.
+
+    Returns True if a schema was written, False if the published base schema for
+    the instance's image could not be found (reported, not an error).
+    """
+    config_dir = instance_dir / "config"
+    image = find_image(instance_dir)
+    if image is None:
+        print(
+            f"Schema not found for {instance_dir.name}: "
+            "no published image pinned in values.yaml; skipping schema generation"
+        )
+        return False
+    try:
+        base = fetch_base_schema(image)
+    except SchemaNotFoundError as exc:
+        print(
+            f"Schema not found for {instance_dir.name} (image {image}): {exc}; "
+            "skipping schema generation"
+        )
+        return False
+
+    support_yamls = sorted(config_dir.glob("*.ibek.support.yaml"))
+    merged = merge_entities(base, support_yamls)
+
+    schema_path = instance_dir / IOC_SCHEMA_NAME
+    schema_path.write_text(json.dumps(merged, indent=2) + "\n")
+    rewrite_ioc_yaml_header(config_dir / "ioc.yaml")
+    return True

--- a/src/ibek/pattern_cmds/sources.py
+++ b/src/ibek/pattern_cmds/sources.py
@@ -96,7 +96,9 @@ def _clone_pattern(uri: str, name: str, version: str | None, dest: Path) -> Path
     cmd = ["git", "clone", "--depth", "1", "--quiet"]
     if version:
         cmd += ["--branch", version]
-    cmd += [uri, str(clone_dir)]
+    # ``--`` terminates option parsing so a uri/path beginning with ``-`` (from
+    # IBEK_PATTERN_LIBRARIES, --source, or a lock label) cannot be read as a flag.
+    cmd += ["--", uri, str(clone_dir)]
     result = subprocess.run(cmd, capture_output=True, text=True)
     if result.returncode != 0:
         raise PatternError(

--- a/src/ibek/pattern_cmds/sources.py
+++ b/src/ibek/pattern_cmds/sources.py
@@ -1,0 +1,153 @@
+"""
+Multi-library source resolution and fetching for ``ibek pattern``.
+
+A pattern name may be qualified with the library it lives in, e.g.
+``ibek-runtime-support:detectorPlugins@1.0.0``. Libraries resolve to a source —
+either a git URL (cloned at the pinned tag) or a local directory (used as-is,
+handy for tests and for vendoring from an un-tagged working copy).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+# The central pattern libraries known to ibek out of the box. Either may be
+# overridden, and further libraries added, via the IBEK_PATTERN_LIBRARIES
+# environment variable ("name=uri,name2=uri2").
+DEFAULT_LIBRARIES: dict[str, str] = {
+    "ibek-runtime-streamdevice": (
+        "https://github.com/epics-containers/ibek-runtime-streamdevice"
+    ),
+    "ibek-runtime-support": (
+        "https://github.com/epics-containers/ibek-runtime-support"
+    ),
+}
+
+_QUALIFIED_RE = re.compile(
+    r"^(?:(?P<library>[^:@]+):)?(?P<name>[^:@]+)(?:@(?P<version>.+))?$"
+)
+
+
+class PatternError(Exception):
+    """A user-facing pattern resolution / fetch error."""
+
+
+@dataclass
+class PatternRef:
+    """A parsed ``[library:]name[@version]`` reference."""
+
+    name: str
+    library: str | None = None
+    version: str | None = None
+
+
+def parse_ref(qualified: str) -> PatternRef:
+    """Parse a ``[library:]name[@version]`` string."""
+    match = _QUALIFIED_RE.match(qualified.strip())
+    if not match:
+        raise PatternError(f"invalid pattern reference: {qualified!r}")
+    return PatternRef(
+        name=match["name"],
+        library=match["library"],
+        version=match["version"],
+    )
+
+
+def library_registry(extra: dict[str, str] | None = None) -> dict[str, str]:
+    """Return the library->source registry (defaults + env + ``extra``)."""
+    registry = dict(DEFAULT_LIBRARIES)
+    env = os.getenv("IBEK_PATTERN_LIBRARIES", "")
+    for item in (piece for piece in env.split(",") if piece.strip()):
+        name, _, uri = item.partition("=")
+        if uri:
+            registry[name.strip()] = uri.strip()
+    if extra:
+        registry.update(extra)
+    return registry
+
+
+def source_label(uri: str) -> str:
+    """Normalise a source URI to the stable label recorded in the lock."""
+    label = re.sub(r"^https?://", "", uri)
+    label = re.sub(r"\.git$", "", label)
+    return label.rstrip("/")
+
+
+def _is_local(uri: str) -> bool:
+    if uri.startswith("file://"):
+        return True
+    if re.match(r"^[a-z]+://", uri):
+        return False
+    return Path(uri).exists()
+
+
+def _local_path(uri: str) -> Path:
+    return Path(uri[len("file://") :] if uri.startswith("file://") else uri)
+
+
+def _clone_pattern(uri: str, name: str, version: str | None, dest: Path) -> Path:
+    """Clone ``uri`` at ``version`` and return the ``name`` pattern folder."""
+    clone_dir = dest / "clone"
+    cmd = ["git", "clone", "--depth", "1", "--quiet"]
+    if version:
+        cmd += ["--branch", version]
+    cmd += [uri, str(clone_dir)]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise PatternError(
+            f"failed to clone {uri}@{version or 'HEAD'}: {result.stderr.strip()}"
+        )
+    pattern_dir = clone_dir / name
+    if not pattern_dir.is_dir():
+        raise PatternError(
+            f"pattern {name!r} not found in {source_label(uri)}@{version or 'HEAD'}"
+        )
+    return pattern_dir
+
+
+def fetch_pattern(uri: str, name: str, version: str | None, dest: Path) -> Path:
+    """Materialise the ``name`` pattern folder from ``uri`` into ``dest``.
+
+    Returns the path to the folder holding the pattern's file-set.
+    """
+    if _is_local(uri):
+        pattern_dir = _local_path(uri) / name
+        if not pattern_dir.is_dir():
+            raise PatternError(f"pattern {name!r} not found in local library {uri}")
+        # Copy so the caller always works against a private, stable tree.
+        staged = dest / name
+        shutil.copytree(pattern_dir, staged)
+        return staged
+    return _clone_pattern(uri, name, version, dest)
+
+
+def resolve_source(
+    ref: PatternRef,
+    source_override: str | None = None,
+    extra_libraries: dict[str, str] | None = None,
+) -> tuple[str, list[str]]:
+    """Resolve a reference to ``(source_uri, candidate_libraries)``.
+
+    If the reference names a library (or ``source_override`` is given) the source
+    is unambiguous. Otherwise every registered library is returned as a candidate
+    to be probed in order by the caller.
+    """
+    if source_override:
+        return source_override, [ref.library or ref.name]
+    registry = library_registry(extra_libraries)
+    if ref.library:
+        if ref.library not in registry:
+            raise PatternError(
+                f"unknown library {ref.library!r}; "
+                f"known: {', '.join(sorted(registry)) or '(none)'}"
+            )
+        return registry[ref.library], [ref.library]
+    if not registry:
+        raise PatternError("no pattern libraries configured")
+    # Unqualified: caller probes each library in registry order.
+    return "", list(registry)

--- a/src/ibek/pattern_cmds/vendor.py
+++ b/src/ibek/pattern_cmds/vendor.py
@@ -59,6 +59,24 @@ def _vendor_files(
     return files
 
 
+def _prune_orphans(config_dir: Path, orphans: set[str]) -> None:
+    """Delete files the previous lock vendored that the new file-set dropped.
+
+    Removes each orphaned path and any parent directories it leaves empty, so a
+    file renamed/removed upstream (or dropped by a version change) cannot linger
+    under ``config/`` and be placed into the IOC by ``ibek runtime place-files``
+    at boot. Scoped to one pattern's prior ``files`` keys, so it never touches
+    another pattern's or user-authored files.
+    """
+    for rel in sorted(orphans):
+        target = config_dir / rel
+        target.unlink(missing_ok=True)
+        parent = target.parent
+        while parent != config_dir and parent.is_dir() and not any(parent.iterdir()):
+            parent.rmdir()
+            parent = parent.parent
+
+
 def _do_vendor(
     ref: PatternRef,
     instance_dir: Path,
@@ -131,11 +149,13 @@ def update(
         if pattern_name not in lock.patterns:
             raise PatternError(f"pattern {pattern_name!r} not in lock")
         existing = lock.patterns[pattern_name]
+        old_files = set(existing.files)
         new_version = version or existing.version
         ref = PatternRef(name=pattern_name, version=new_version)
         label, resolved_version, files = _do_vendor(
             ref, instance_dir, source_override or existing.source, extra_libraries
         )
+        _prune_orphans(_config_dir(instance_dir), old_files - set(files))
         lock.set_pattern(pattern_name, resolved_version, label, files)
     lock.save()
     generate_instance_schema(instance_dir)
@@ -156,6 +176,7 @@ def restore(
         if pattern_name not in lock.patterns:
             raise PatternError(f"pattern {pattern_name!r} not in lock")
         entry = lock.patterns[pattern_name]
+        old_files = set(entry.files)
         ref = PatternRef(name=pattern_name, version=entry.version)
         with tempfile.TemporaryDirectory() as tmp:
             pattern_dir = fetch_pattern(
@@ -164,7 +185,8 @@ def restore(
                 ref.version,
                 Path(tmp),
             )
-            _vendor_files(pattern_dir, config_dir, entry.source, entry.version)
+            files = _vendor_files(pattern_dir, config_dir, entry.source, entry.version)
+        _prune_orphans(config_dir, old_files - set(files))
     generate_instance_schema(instance_dir)
 
 

--- a/src/ibek/pattern_cmds/vendor.py
+++ b/src/ibek/pattern_cmds/vendor.py
@@ -1,0 +1,211 @@
+"""
+Vendoring orchestration for ``ibek pattern`` — add / update / check / restore.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from ibek.globals import RUNTIME_LOCK_NAME
+
+from .lock import RuntimeLock, file_hash, is_dirty, stamp_content
+from .schema import generate_instance_schema
+from .sources import (
+    PatternError,
+    PatternRef,
+    fetch_pattern,
+    parse_ref,
+    resolve_source,
+    source_label,
+)
+
+
+class CheckResult:
+    """Outcome of ``ibek pattern check`` for one instance."""
+
+    def __init__(self) -> None:
+        self.failures: list[str] = []
+        self.warnings: list[str] = []
+
+    @property
+    def ok(self) -> bool:
+        return not self.failures
+
+
+def _config_dir(instance_dir: Path) -> Path:
+    return instance_dir / "config"
+
+
+def _lock_path(instance_dir: Path) -> Path:
+    return instance_dir / RUNTIME_LOCK_NAME
+
+
+def _vendor_files(
+    pattern_dir: Path, config_dir: Path, source: str, version: str
+) -> dict[str, str]:
+    """Stamp + write every file in ``pattern_dir`` into ``config_dir``.
+
+    Returns the ``relpath -> sha256`` map for the lock.
+    """
+    files: dict[str, str] = {}
+    for src in sorted(p for p in pattern_dir.rglob("*") if p.is_file()):
+        rel = src.relative_to(pattern_dir)
+        stamped = stamp_content(rel, src.read_bytes(), source, version)
+        dest = config_dir / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(stamped)
+        files[str(rel)] = file_hash(stamped)
+    return files
+
+
+def _do_vendor(
+    ref: PatternRef,
+    instance_dir: Path,
+    source_override: str | None,
+    extra_libraries: dict[str, str] | None,
+) -> tuple[str, str, dict[str, str]]:
+    """Fetch + vendor ``ref`` into the instance; return (source_label, version, files)."""
+    uri, candidates = resolve_source(ref, source_override, extra_libraries)
+    config_dir = _config_dir(instance_dir)
+    config_dir.mkdir(parents=True, exist_ok=True)
+
+    last_error: Exception | None = None
+    sources = [uri] if uri else _candidate_uris(candidates, extra_libraries)
+    for candidate_uri in sources:
+        with tempfile.TemporaryDirectory() as tmp:
+            try:
+                pattern_dir = fetch_pattern(
+                    candidate_uri, ref.name, ref.version, Path(tmp)
+                )
+            except PatternError as exc:
+                last_error = exc
+                continue
+            label = source_label(candidate_uri)
+            files = _vendor_files(pattern_dir, config_dir, label, ref.version or "HEAD")
+            return label, ref.version or "HEAD", files
+    raise PatternError(
+        f"could not resolve pattern {ref.name!r}: {last_error or 'no libraries'}"
+    )
+
+
+def _candidate_uris(
+    libraries: list[str], extra_libraries: dict[str, str] | None
+) -> list[str]:
+    from .sources import library_registry
+
+    registry = library_registry(extra_libraries)
+    return [registry[name] for name in libraries if name in registry]
+
+
+def add(
+    qualified: str,
+    instance_dir: Path,
+    source_override: str | None = None,
+    extra_libraries: dict[str, str] | None = None,
+) -> None:
+    """Vendor a pattern into ``instance_dir`` and write the lock + schema."""
+    ref = parse_ref(qualified)
+    label, version, files = _do_vendor(
+        ref, instance_dir, source_override, extra_libraries
+    )
+    lock = RuntimeLock(_lock_path(instance_dir))
+    lock.set_pattern(ref.name, version, label, files)
+    lock.save()
+    generate_instance_schema(instance_dir)
+
+
+def update(
+    name: str | None,
+    instance_dir: Path,
+    version: str | None = None,
+    source_override: str | None = None,
+    extra_libraries: dict[str, str] | None = None,
+) -> None:
+    """Re-vendor one (or all) patterns, optionally moving the pinned version."""
+    lock = RuntimeLock(_lock_path(instance_dir))
+    if not lock.patterns:
+        raise PatternError(f"no patterns to update in {instance_dir}")
+    names = [name] if name else list(lock.patterns)
+    for pattern_name in names:
+        if pattern_name not in lock.patterns:
+            raise PatternError(f"pattern {pattern_name!r} not in lock")
+        existing = lock.patterns[pattern_name]
+        new_version = version or existing.version
+        ref = PatternRef(name=pattern_name, version=new_version)
+        label, resolved_version, files = _do_vendor(
+            ref, instance_dir, source_override or existing.source, extra_libraries
+        )
+        lock.set_pattern(pattern_name, resolved_version, label, files)
+    lock.save()
+    generate_instance_schema(instance_dir)
+
+
+def restore(
+    name: str | None,
+    instance_dir: Path,
+    extra_libraries: dict[str, str] | None = None,
+) -> None:
+    """Revert vendored files to the pinned version recorded in the lock."""
+    lock = RuntimeLock(_lock_path(instance_dir))
+    if not lock.patterns:
+        raise PatternError(f"no patterns to restore in {instance_dir}")
+    names = [name] if name else list(lock.patterns)
+    config_dir = _config_dir(instance_dir)
+    for pattern_name in names:
+        if pattern_name not in lock.patterns:
+            raise PatternError(f"pattern {pattern_name!r} not in lock")
+        entry = lock.patterns[pattern_name]
+        ref = PatternRef(name=pattern_name, version=entry.version)
+        with tempfile.TemporaryDirectory() as tmp:
+            pattern_dir = fetch_pattern(
+                _restore_uri(entry.source, extra_libraries),
+                ref.name,
+                ref.version,
+                Path(tmp),
+            )
+            _vendor_files(pattern_dir, config_dir, entry.source, entry.version)
+    generate_instance_schema(instance_dir)
+
+
+def _restore_uri(source: str, extra_libraries: dict[str, str] | None) -> str:
+    """Map a recorded lock ``source`` label back to a fetchable URI."""
+    from .sources import library_registry
+
+    for uri in library_registry(extra_libraries).values():
+        if source_label(uri) == source:
+            return uri
+    # The label is itself a host/path; reconstruct an https URL for github.
+    if source.startswith("github.com/"):
+        return "https://" + source
+    return source
+
+
+def check(
+    instance_dir: Path,
+    allow_dirty: bool = False,
+) -> CheckResult:
+    """Verify vendored files against the lock for one instance."""
+    result = CheckResult()
+    lock = RuntimeLock(_lock_path(instance_dir))
+    config_dir = _config_dir(instance_dir)
+    for pattern_name, entry in lock.patterns.items():
+        for rel, expected in entry.files.items():
+            target = config_dir / rel
+            if is_dirty(expected):
+                reason = expected.partition("#")[2].strip() or "no reason given"
+                result.warnings.append(f"{pattern_name}:{rel} marked DIRTY ({reason})")
+                continue
+            if not target.exists():
+                result.failures.append(f"{pattern_name}:{rel} missing vendored file")
+                continue
+            actual = file_hash(target.read_bytes())
+            if actual != expected:
+                result.failures.append(
+                    f"{pattern_name}:{rel} hash mismatch "
+                    f"(expected {expected}, got {actual})"
+                )
+    if allow_dirty:
+        result.warnings.extend(result.failures)
+        result.failures = []
+    return result

--- a/src/ibek/runtime_cmds/commands.py
+++ b/src/ibek/runtime_cmds/commands.py
@@ -91,6 +91,24 @@ def generate2(
 
 
 @runtime_cli.command()
+def place_files(
+    config_folder: Path = typer.Argument(
+        ...,
+        help="The IOC instance config folder containing runtime artifacts",
+        exists=True,
+        dir_okay=True,
+        file_okay=False,
+        autocompletion=lambda: [],
+    ),
+):
+    """
+    Place runtime artifacts (proto / db / ...) from an IOC instance config
+    folder into their runtime search-path locations for IOC boot.
+    """
+    place_runtime_files(config_folder)
+
+
+@runtime_cli.command()
 def generate(
     instance: Path = typer.Argument(
         ...,
@@ -111,6 +129,32 @@ def generate(
     pvi: bool = typer.Option(True, help="generate pvi PVs and opi files"),
 ):
     do_generate([instance], definitions, output_folder, pvi)
+
+
+def place_runtime_files(config_dir: Path) -> None:
+    """Place declared runtime artifacts from an IOC instance config folder.
+
+    Copies the runtime input files vendored / dropped into ``config_dir`` into
+    the runtime search-path locations the IOC boot expects, so support patterns
+    (StreamDevice protos, extra db/templates) work with no per-image start.sh
+    fork:
+
+      - ``*.proto`` / ``*.protocol`` -> ``GLOBALS.RUNTIME_PROTOCOL``
+        (the directory ``STREAM_PROTOCOL_PATH`` points at)
+      - ``*.db`` / ``*.template``    -> ``GLOBALS.RUNTIME_DB``
+
+    Files are copied (not symlinked) so the runtime stage is self-contained,
+    matching the behaviour of the start.sh proto-copy this step replaces.
+    """
+    placements = [
+        (("*.proto", "*.protocol"), GLOBALS.RUNTIME_PROTOCOL),
+        (("*.db", "*.template"), GLOBALS.RUNTIME_DB),
+    ]
+    for patterns, target in placements:
+        for pattern in patterns:
+            for src in sorted(config_dir.glob(pattern)):
+                target.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, target / src.name)
 
 
 def do_generate(

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -1,0 +1,356 @@
+"""
+Tests for the ``ibek pattern`` runtime-support vendoring subsystem.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from ibek.__main__ import cli
+from ibek.globals import IOC_SCHEMA_NAME, RUNTIME_LOCK_NAME
+from ibek.pattern_cmds import schema, vendor
+from ibek.pattern_cmds.lock import (
+    RuntimeLock,
+    comment_prefix,
+    file_hash,
+    stamp_content,
+    vendored_header,
+)
+from ibek.pattern_cmds.schema import (
+    generate_instance_schema,
+    generate_schema_dict,
+    merge_entities,
+    resolve_image_ref,
+)
+from ibek.pattern_cmds.sources import parse_ref
+
+runner = CliRunner()
+
+SUPPORT_HEADER = "# yaml-language-server: $schema=../schemas/ibek.support.schema.json"
+MYDEVICE_SUPPORT = f"""{SUPPORT_HEADER}
+
+module: mydevice
+
+entity_models:
+  - name: mydevice
+    description: a test device
+    parameters:
+      name:
+        type: id
+        description: identifier
+      P:
+        type: str
+        description: pv prefix
+"""
+MYDEVICE_PROTO = 'Terminator = CR LF;\ngetX { out "X?"; in "%f"; }\n'
+
+
+@pytest.fixture
+def library(tmp_path: Path) -> Path:
+    """A local pattern library with a single ``mydevice`` pattern."""
+    pattern = tmp_path / "lib" / "mydevice"
+    pattern.mkdir(parents=True)
+    (pattern / "mydevice.ibek.support.yaml").write_text(MYDEVICE_SUPPORT)
+    (pattern / "mydevice.proto").write_text(MYDEVICE_PROTO)
+    return tmp_path / "lib"
+
+
+def make_instance(root: Path, image: str = "REPLACE_WITH_IMAGE_URI") -> Path:
+    """Create a minimal IOC instance folder."""
+    instance = root / "bl01t-ea-test-01"
+    (instance / "config").mkdir(parents=True)
+    (instance / "values.yaml").write_text(f"ioc-instance:\n  image: {image}\n")
+    (instance / "config" / "ioc.yaml").write_text(
+        "# yaml-language-server: $schema=/epics/ibek-defs/ioc.schema.json\n"
+        "ioc_name: test\nentities: []\n"
+    )
+    return instance
+
+
+# --------------------------------------------------------------------------- #
+# header / hashing
+# --------------------------------------------------------------------------- #
+def test_vendored_header_deterministic():
+    src = "github.com/epics-containers/ibek-runtime-streamdevice"
+    header = vendored_header(Path("x.proto"), src, "1.0.0")
+    assert header == f"# Vendored from {src}@1.0.0 — DO NOT EDIT"
+    # deterministic: same inputs -> identical bytes
+    a = stamp_content(Path("x.proto"), b"body\n", src, "1.0.0")
+    b = stamp_content(Path("x.proto"), b"body\n", src, "1.0.0")
+    assert a == b
+    assert a.startswith(header.encode())
+    assert a.endswith(b"body\n")
+
+
+def test_comment_prefix_default():
+    assert comment_prefix(Path("a.proto")) == "#"
+    assert comment_prefix(Path("a.weirdext")) == "#"
+
+
+# --------------------------------------------------------------------------- #
+# add / lock
+# --------------------------------------------------------------------------- #
+def test_add_vendors_files_with_header_and_lock(tmp_path: Path, library: Path):
+    instance = make_instance(tmp_path)
+    vendor.add("mydevice@1.0.0", instance, source_override=str(library))
+
+    proto = instance / "config" / "mydevice.proto"
+    support = instance / "config" / "mydevice.ibek.support.yaml"
+    assert proto.exists() and support.exists()
+    # real files, not symlinks
+    assert not proto.is_symlink()
+    # header injected at the top, original content preserved below
+    text = proto.read_text()
+    assert text.startswith("# Vendored from ")
+    assert "@1.0.0 — DO NOT EDIT" in text.splitlines()[0]
+    assert "getX" in text
+
+    lock = RuntimeLock(instance / RUNTIME_LOCK_NAME)
+    assert set(lock.patterns) == {"mydevice"}
+    entry = lock.patterns["mydevice"]
+    assert entry.version == "1.0.0"
+    assert "ibek-runtime-streamdevice" not in entry.source  # local source label
+    # recorded hash matches the bytes on disk (header included)
+    assert entry.files["mydevice.proto"] == file_hash(proto.read_bytes())
+    assert set(entry.files) == {"mydevice.proto", "mydevice.ibek.support.yaml"}
+
+
+# --------------------------------------------------------------------------- #
+# check / dirty-state machine
+# --------------------------------------------------------------------------- #
+def test_check_pristine_passes(tmp_path: Path, library: Path):
+    instance = make_instance(tmp_path)
+    vendor.add("mydevice@1.0.0", instance, source_override=str(library))
+    result = vendor.check(instance)
+    assert result.ok
+    assert not result.failures
+
+
+def test_check_detects_drift(tmp_path: Path, library: Path):
+    instance = make_instance(tmp_path)
+    vendor.add("mydevice@1.0.0", instance, source_override=str(library))
+    proto = instance / "config" / "mydevice.proto"
+    proto.write_text(proto.read_text() + "# local hack\n")
+
+    result = vendor.check(instance)
+    assert not result.ok
+    assert any("mydevice.proto" in f and "mismatch" in f for f in result.failures)
+
+    # --allow-dirty downgrades the failure to a warning
+    relaxed = vendor.check(instance, allow_dirty=True)
+    assert relaxed.ok
+    assert relaxed.warnings
+
+
+def test_check_missing_file_fails(tmp_path: Path, library: Path):
+    instance = make_instance(tmp_path)
+    vendor.add("mydevice@1.0.0", instance, source_override=str(library))
+    (instance / "config" / "mydevice.proto").unlink()
+    result = vendor.check(instance)
+    assert not result.ok
+    assert any("missing" in f for f in result.failures)
+
+
+def test_check_respects_dirty_marker(tmp_path: Path, library: Path):
+    instance = make_instance(tmp_path)
+    vendor.add("mydevice@1.0.0", instance, source_override=str(library))
+    proto = instance / "config" / "mydevice.proto"
+    proto.write_text(proto.read_text() + "# JIRA-123 relay fix\n")
+
+    lock = RuntimeLock(instance / RUNTIME_LOCK_NAME)
+    lock.patterns["mydevice"].files["mydevice.proto"] = "DIRTY # JIRA-123 relay fix"
+    lock.save()
+
+    result = vendor.check(instance)
+    assert result.ok  # dirty marker is not a failure
+    assert any("DIRTY" in w for w in result.warnings)
+
+
+# --------------------------------------------------------------------------- #
+# update / restore
+# --------------------------------------------------------------------------- #
+def test_update_moves_version(tmp_path: Path, library: Path):
+    instance = make_instance(tmp_path)
+    vendor.add("mydevice@1.0.0", instance, source_override=str(library))
+    # change the library content and re-vendor at a new version
+    (library / "mydevice" / "mydevice.proto").write_text(MYDEVICE_PROTO + "getY {}\n")
+    vendor.update("mydevice", instance, version="2.0.0", source_override=str(library))
+
+    lock = RuntimeLock(instance / RUNTIME_LOCK_NAME)
+    assert lock.patterns["mydevice"].version == "2.0.0"
+    proto = instance / "config" / "mydevice.proto"
+    assert "getY" in proto.read_text()
+    assert "@2.0.0 — DO NOT EDIT" in proto.read_text().splitlines()[0]
+    assert vendor.check(instance).ok
+
+
+def test_restore_reverts_local_edit(tmp_path: Path, library: Path):
+    instance = make_instance(tmp_path)
+    vendor.add("mydevice@1.0.0", instance, source_override=str(library))
+    proto = instance / "config" / "mydevice.proto"
+    proto.write_text("corrupted\n")
+    assert not vendor.check(instance).ok
+
+    vendor.restore("mydevice", instance)
+    assert vendor.check(instance).ok
+    assert "getX" in proto.read_text()
+
+
+# --------------------------------------------------------------------------- #
+# qualified-name parsing
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "text, library, name, version",
+    [
+        ("lakeshore340", None, "lakeshore340", None),
+        ("lakeshore340@1.2", None, "lakeshore340", "1.2"),
+        ("lib:dev@0.1.0", "lib", "dev", "0.1.0"),
+        (
+            "ibek-runtime-support:detectorPlugins@2025.1",
+            "ibek-runtime-support",
+            "detectorPlugins",
+            "2025.1",
+        ),
+    ],
+)
+def test_parse_ref(text, library, name, version):
+    ref = parse_ref(text)
+    assert (ref.library, ref.name, ref.version) == (library, name, version)
+
+
+# --------------------------------------------------------------------------- #
+# image ref resolution
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "image, expected",
+    [
+        (
+            "ghcr.io/epics-containers/ioc-adsimdetector-runtime:2025.11.1",
+            ("epics-containers", "ioc-adsimdetector", "2025.11.1"),
+        ),
+        (
+            "ghcr.io/epics-containers/ioc-streamdevice-developer:1.0",
+            ("epics-containers", "ioc-streamdevice", "1.0"),
+        ),
+        (
+            "ghcr.io/myorg/ioc-foo-rtems-beatnik-runtime:3.2.1",
+            ("myorg", "ioc-foo", "3.2.1"),
+        ),
+    ],
+)
+def test_resolve_image_ref(image, expected):
+    assert resolve_image_ref(image) == expected
+
+
+# --------------------------------------------------------------------------- #
+# schema merge
+# --------------------------------------------------------------------------- #
+def test_merge_entities_grafts_new_types(samples: Path):
+    support = sorted((samples / "support").glob("*.ibek.support.yaml"))
+    base = generate_schema_dict([support[0]])
+    before = set(base["properties"]["entities"]["items"]["discriminator"]["mapping"])
+    merged = merge_entities(base, [support[1]])
+    mapping = merged["properties"]["entities"]["items"]["discriminator"]["mapping"]
+    after = set(mapping)
+    added = after - before
+    assert added  # new entity types grafted in
+    # every new mapping target resolves to a $def that now exists
+    for disc in added:
+        ref = mapping[disc].split("/")[-1]
+        assert ref in merged["$defs"]
+    # built-ins are not duplicated in oneOf
+    one_of = merged["properties"]["entities"]["items"]["oneOf"]
+    refs = [o["$ref"] for o in one_of]
+    assert len(refs) == len(set(refs))
+
+
+# --------------------------------------------------------------------------- #
+# instance schema generation
+# --------------------------------------------------------------------------- #
+def test_generate_instance_schema_merges_and_rewrites_header(
+    tmp_path: Path, library: Path, samples: Path, monkeypatch
+):
+    instance = make_instance(
+        tmp_path, image="ghcr.io/epics-containers/ioc-adsimdetector-runtime:2025.11.1"
+    )
+    monkeypatch.setenv("IBEK_SCHEMA_CACHE", str(tmp_path / "cache"))
+    # base schema served for the image (built from a real sample module)
+    support = sorted((samples / "support").glob("*.ibek.support.yaml"))
+    base = generate_schema_dict([support[0]])
+    monkeypatch.setattr(schema, "_http_get", lambda url: json.dumps(base).encode())
+    # vendor mydevice so its support yaml is in config/
+    vendor.add("mydevice@1.0.0", instance, source_override=str(library))
+
+    assert generate_instance_schema(instance) is True
+    schema_file = instance / IOC_SCHEMA_NAME
+    assert schema_file.exists()
+    produced = json.loads(schema_file.read_text())
+    mapping = produced["properties"]["entities"]["items"]["discriminator"]["mapping"]
+    assert "mydevice.mydevice" in mapping  # vendored entity merged into base
+    # ioc.yaml header rewritten to the sibling schema
+    header = (instance / "config" / "ioc.yaml").read_text().splitlines()[0]
+    assert header == f"# yaml-language-server: $schema=../{IOC_SCHEMA_NAME}"
+
+
+def test_generate_instance_schema_no_image_is_graceful(tmp_path: Path, capsys):
+    instance = make_instance(tmp_path, image="REPLACE_WITH_IMAGE_URI")
+    assert generate_instance_schema(instance) is False
+    assert not (instance / IOC_SCHEMA_NAME).exists()
+    assert "Schema not found" in capsys.readouterr().out
+
+
+def test_generate_instance_schema_fetch_failure_is_graceful(
+    tmp_path: Path, monkeypatch, capsys
+):
+    instance = make_instance(
+        tmp_path, image="ghcr.io/epics-containers/ioc-missing-runtime:9.9.9"
+    )
+    monkeypatch.setenv("IBEK_SCHEMA_CACHE", str(tmp_path / "cache"))
+
+    def boom(url):
+        raise schema.SchemaNotFoundError("404")
+
+    monkeypatch.setattr(schema, "_http_get", boom)
+    assert generate_instance_schema(instance) is False
+    assert "Schema not found" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# CLI integration
+# --------------------------------------------------------------------------- #
+def test_cli_add_and_check(tmp_path: Path, library: Path):
+    instance = make_instance(tmp_path)
+    add = runner.invoke(
+        cli,
+        ["pattern", "add", "mydevice@1.0.0", str(instance), "--source", str(library)],
+    )
+    assert add.exit_code == 0, add.output
+    check = runner.invoke(cli, ["pattern", "check", str(instance)])
+    assert check.exit_code == 0, check.output
+
+
+def test_cli_check_fails_on_drift(tmp_path: Path, library: Path):
+    instance = make_instance(tmp_path)
+    runner.invoke(
+        cli,
+        ["pattern", "add", "mydevice@1.0.0", str(instance), "--source", str(library)],
+    )
+    proto = instance / "config" / "mydevice.proto"
+    proto.write_text("tampered\n")
+    result = runner.invoke(cli, ["pattern", "check", str(instance)])
+    assert result.exit_code == 1
+    assert "mismatch" in result.output
+
+
+def test_cli_check_allow_dirty_env(tmp_path: Path, library: Path, monkeypatch):
+    instance = make_instance(tmp_path)
+    runner.invoke(
+        cli,
+        ["pattern", "add", "mydevice@1.0.0", str(instance), "--source", str(library)],
+    )
+    (instance / "config" / "mydevice.proto").write_text("tampered\n")
+    monkeypatch.setenv("IBEK_ALLOW_DIRTY", "1")
+    result = runner.invoke(cli, ["pattern", "check", str(instance)])
+    assert result.exit_code == 0, result.output

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -3,6 +3,9 @@ Tests for the ``ibek pattern`` runtime-support vendoring subsystem.
 """
 
 import json
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -264,6 +267,33 @@ def test_merge_entities_grafts_new_types(samples: Path):
     one_of = merged["properties"]["entities"]["items"]["oneOf"]
     refs = [o["$ref"] for o in one_of]
     assert len(refs) == len(set(refs))
+
+
+def test_merge_entities_byte_stable_across_hashseed(samples: Path):
+    """Merge output must not depend on PYTHONHASHSEED.
+
+    The per-instance ioc.schema.json is committed and CI/pre-commit re-generate
+    it and diff-fail on drift, so the merge must be byte-stable across processes
+    (set/closure iteration order must not leak into the output).
+    """
+    support = sorted((samples / "support").glob("*.ibek.support.yaml"))
+    script = (
+        "import json;"
+        "from pathlib import Path;"
+        "from ibek.pattern_cmds.schema import generate_schema_dict, merge_entities;"
+        f"b=generate_schema_dict([Path(r'{support[0]}')]);"
+        f"m=merge_entities(b,[Path(r'{support[1]}')]);"
+        "print(json.dumps(m, indent=2))"
+    )
+    outputs = []
+    for seed in ("0", "1", "42"):
+        env = {**os.environ, "PYTHONHASHSEED": seed}
+        result = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, text=True, env=env
+        )
+        assert result.returncode == 0, result.stderr
+        outputs.append(result.stdout)
+    assert outputs[0] == outputs[1] == outputs[2]
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -189,6 +189,31 @@ def test_update_moves_version(tmp_path: Path, library: Path):
     assert vendor.check(instance).ok
 
 
+def test_update_prunes_orphaned_files(tmp_path: Path, library: Path):
+    """A file dropped by the new version must leave neither disk nor lock residue."""
+    instance = make_instance(tmp_path)
+    # give the pattern a nested file so we also exercise empty-dir pruning
+    (library / "mydevice" / "db").mkdir()
+    (library / "mydevice" / "db" / "extra.db").write_text('record(ai, "X") {}\n')
+    vendor.add("mydevice@1.0.0", instance, source_override=str(library))
+    nested = instance / "config" / "db" / "extra.db"
+    assert nested.exists()
+
+    # the new version drops the nested db file entirely
+    (library / "mydevice" / "db" / "extra.db").unlink()
+    vendor.update("mydevice", instance, version="2.0.0", source_override=str(library))
+
+    assert not nested.exists()  # orphan removed from disk
+    assert not nested.parent.exists()  # now-empty config/db/ pruned
+    lock = RuntimeLock(instance / RUNTIME_LOCK_NAME)
+    assert "db/extra.db" not in lock.patterns["mydevice"].files  # gone from the lock
+    assert set(lock.patterns["mydevice"].files) == {
+        "mydevice.proto",
+        "mydevice.ibek.support.yaml",
+    }
+    assert vendor.check(instance).ok
+
+
 def test_restore_reverts_local_edit(tmp_path: Path, library: Path):
     instance = make_instance(tmp_path)
     vendor.add("mydevice@1.0.0", instance, source_override=str(library))

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2,7 +2,24 @@
 Tests for the ibek runtime commands
 """
 
+from ibek.globals import GLOBALS
 from ibek.runtime_cmds.autosave import AutosaveGenerator, link_req_files
+from ibek.runtime_cmds.commands import place_runtime_files
+
+
+def test_place_runtime_files(tmp_epics_root):
+    """Runtime artifacts in config/ are placed into their boot locations."""
+    config_dir = GLOBALS.IOC_FOLDER / GLOBALS.CONFIG_DIR_NAME
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "device.proto").write_text("Terminator = CR;\n")
+    (config_dir / "extra.db").write_text("record(ai, x) {}\n")
+    (config_dir / "ioc.yaml").write_text("ioc_name: test\n")  # not placed
+
+    place_runtime_files(config_dir)
+
+    assert (GLOBALS.RUNTIME_PROTOCOL / "device.proto").exists()
+    assert (GLOBALS.RUNTIME_DB / "extra.db").exists()
+    assert not (GLOBALS.RUNTIME_PROTOCOL / "ioc.yaml").exists()
 
 
 def test_autosave_generator(samples, tmp_epics_root):


### PR DESCRIPTION
## Summary

Implements the keystone vendoring subsystem from #353: a new `ibek pattern`
command group that vendors runtime-support patterns (StreamDevice device support,
AreaDetector plugin sets, …) from a central library into an IOC instance at a
pinned version, with content-hash integrity.

## What changed

- **`ibek pattern add / update / check / restore`** — vendor an arbitrary file-set
  pattern from a central library at a pinned version; `runtime-lock.yaml` (instance
  root) records `version` + `source` + per-file SHA-256 over the vendored-as-written
  bytes.
- **Deterministic vendored header** `# Vendored from <source>@<version> — DO NOT EDIT`
  injected before hashing, so `check` is a trivial `sha256(file) == lock`.
- **Multi-library source resolution** — qualified `library:name@version`, a built-in
  registry + `IBEK_PATTERN_LIBRARIES` / `--source` overrides; git-tag or local sources.
- **Dirty-state machine** — `--allow-dirty` / `IBEK_ALLOW_DIRTY=1` downgrade mismatches
  to warnings; in-lock `DIRTY # reason` markers for committed known-dirty files.
- **`ibek pattern schema`** — self-contained per-instance `ioc.schema.json`: fetch the
  image's published base schema (`values.yaml` image tag → release asset, cached per
  tag) and programmatically merge vendored/local entities into the discriminated
  `oneOf` / `discriminator.mapping` / `$defs`; rewrites the `ioc.yaml` `$schema` header.
  A missing published schema is reported, not an error.
- **Runtime file placement** — `ibek runtime place-files` copies config `proto`/`db`
  artifacts into their boot locations (replaces the per-image `start.sh` fork,
  epics-containers/ioc-streamdevice#1).

## Validation

- New `tests/test_pattern.py` (24 tests) + a runtime-placement test, covering add/lock/
  header determinism, check drift + DIRTY + `--allow-dirty`, update/restore, image-ref
  resolution, the schema merge (incl. a **cross-`PYTHONHASHSEED` byte-stability**
  regression test so the CI schema-freshness diff cannot flap), and the graceful
  "schema not found" fallback. Full suite green; ruff + mypy clean.
- Exercised end-to-end against real `v0.1.0` library tags in gilesknap/t01-services.

Fixes #353


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `ibek pattern` command set for managing vendored runtime-support patterns, including add, update, check, restore, and schema generation.
  * Added a runtime file placement command that copies protocol and database artifacts into the correct runtime locations.

* **Bug Fixes**
  * Improved validation and tracking so vendored files are checked against recorded versions and hashes.
  * Added support for generating and updating project schema references for better editor assistance.

* **Tests**
  * Added coverage for vendoring, restore, drift detection, schema generation, and runtime file placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->