### PR TITLE
pattern: --name as filter option + fix update source-label resolution

### DIFF
--- a/docs/explanations/decisions/0003-vendored-pattern-tag-is-authority.md
+++ b/docs/explanations/decisions/0003-vendored-pattern-tag-is-authority.md
@@ -1,0 +1,45 @@
+# 3. Vendored pattern tag is the authority
+
+## Status
+
+Accepted
+
+## Context
+
+`ibek pattern` vendors a runtime-support pattern from a central library into an
+IOC instance at a pinned version. The files are copied into the instance's
+`config/` with a `# Vendored from <source>@<version> — DO NOT EDIT` header, and
+each file's SHA-256 is recorded in `runtime-lock.yaml` at the instance root.
+
+This raises the question of where the *authority* for a pattern's content lives:
+the upstream library at its tag, or the hashes captured in the lock. The two
+answers lead to materially different behaviour for `update` and `restore`, and
+to whether the lock must defend against upstream content changing under a tag.
+
+## Decision
+
+The **upstream library at its tag is the source of truth**, and tags are
+treated as **immutable** (a published tag is never moved to a new commit).
+
+The `runtime-lock.yaml` SHA-256 entries are an **integrity check for local
+drift only** — they let `ibek pattern check` detect hand-edits to vendored
+files. They are deliberately *not* a content store and *not* a tamper-evident
+pin against the upstream library.
+
+## Consequences
+
+- `restore` re-clones the pattern at the recorded tag and overwrites the
+  vendored files, trusting the fetched bytes. It does not verify them against
+  the recorded hashes and keeps the lock unchanged.
+- `update` with no `--version` re-vendors the *same* tag and re-records the
+  hashes; `update --version X` moves the pin. Because tags are immutable,
+  `update` with no `--version` and `restore` produce identical bytes, and
+  `check` remains a pure local-drift signal.
+- A yank or retag of an upstream pattern version is accepted behaviour, not a
+  case the tooling defends against — re-pin to a new immutable tag instead.
+- We do not add restore-side hash verification or a local content cache. Either
+  would only matter if the immutable-tag policy were abandoned; revisit this ADR
+  if that ever changes.
+
+See [ADR 4](./0004-vendor-runtime-support-over-submodules.md) for the underlying
+decision to vendor runtime support in the first place.

--- a/docs/explanations/decisions/0004-vendor-runtime-support-over-submodules.md
+++ b/docs/explanations/decisions/0004-vendor-runtime-support-over-submodules.md
@@ -1,0 +1,46 @@
+# 4. Vendor runtime support over submodule + symlink
+
+## Status
+
+Accepted
+
+## Context
+
+An IOC instance needs its runtime-support file-set: StreamDevice protocol
+files, AreaDetector plugin sets, support `*.ibek.support.yaml`, and the
+associated `.proto`/`.protocol`/`.template`/`.db`. Historically these were
+consumed by pointing the instance at a central support module via a git
+submodule and symlinks into it.
+
+That coupling made "what is this IOC actually running?" hard to answer from the
+committed instance alone: the answer depended on the submodule commit and on
+whatever the symlinks resolved to in the build image, so a pattern's version was
+tied to the image rather than to the instance.
+
+## Decision
+
+Consume runtime support as **per-instance vendored copies**, pinned by a
+`runtime-lock.yaml` at the instance root, instead of submodule + symlink.
+
+`ibek pattern add|update|check|restore|schema` copies a pattern's file-set from
+a central library (e.g. `ibek-runtime-streamdevice`, `ibek-runtime-support`)
+into the instance's `config/`, prepends a deterministic
+`# Vendored from <source>@<version> — DO NOT EDIT` header, and records each
+file's SHA-256 in the lock. A self-contained `ioc.schema.json` is generated per
+instance by merging the vendored support entities into the image's published
+base schema.
+
+## Consequences
+
+- An instance gains a version axis for its support that is independent of the
+  image: the committed lock answers "what is this IOC running?" with
+  cryptographic certainty.
+- Vendored files are real files (not symlinks) and carry a DO-NOT-EDIT header;
+  `ibek pattern check` enforces their integrity against the lock so accidental
+  edits are caught.
+- `config/` remains the Kubernetes ConfigMap payload (runtime inputs only,
+  bounded by the ConfigMap size limit), now self-contained rather than
+  resolved through a submodule at build time.
+- The central libraries become the single upstream source for patterns; see
+  [ADR 3](./0003-vendored-pattern-tag-is-authority.md) for how their tags relate
+  to the lock.

--- a/src/ibek/pattern_cmds/commands.py
+++ b/src/ibek/pattern_cmds/commands.py
@@ -47,6 +47,15 @@ SourceOpt = Annotated[
     ),
 ]
 
+NameOpt = Annotated[
+    str | None,
+    typer.Option(
+        "--name",
+        "-n",
+        help="Restrict to a single pattern by name (default: all in the lock)",
+    ),
+]
+
 
 def _fail(exc: Exception) -> None:
     log.error(str(exc))
@@ -75,11 +84,8 @@ def add(
 
 @pattern_cli.command()
 def update(
-    name: Annotated[
-        str | None,
-        typer.Argument(help="Pattern name to update (default: all in the lock)"),
-    ] = None,
     instance: InstanceArg = Path("."),
+    name: NameOpt = None,
     version: Annotated[
         str | None,
         typer.Option("--version", "-v", help="New pinned version to vendor"),
@@ -120,11 +126,8 @@ def check(
 
 @pattern_cli.command()
 def restore(
-    name: Annotated[
-        str | None,
-        typer.Argument(help="Pattern name to restore (default: all in the lock)"),
-    ] = None,
     instance: InstanceArg = Path("."),
+    name: NameOpt = None,
 ):
     """Revert vendored files to the version pinned in runtime-lock.yaml."""
     try:

--- a/src/ibek/pattern_cmds/vendor.py
+++ b/src/ibek/pattern_cmds/vendor.py
@@ -83,7 +83,14 @@ def _do_vendor(
     source_override: str | None,
     extra_libraries: dict[str, str] | None,
 ) -> tuple[str, str, dict[str, str]]:
-    """Fetch + vendor ``ref`` into the instance; return (source_label, version, files)."""
+    """Fetch + vendor ``ref`` into the instance; return (source_label, version, files).
+
+    An explicit ``source_override`` (a user ``--source`` or a recorded lock
+    label) is normalised to a fetchable URI here — the single point every caller
+    (add / update / restore) shares, so none can clone a scheme-stripped label.
+    """
+    if source_override:
+        source_override = _source_uri(source_override, extra_libraries)
     uri, candidates = resolve_source(ref, source_override, extra_libraries)
     config_dir = _config_dir(instance_dir)
     config_dir.mkdir(parents=True, exist_ok=True)
@@ -133,6 +140,42 @@ def add(
     generate_instance_schema(instance_dir)
 
 
+def _locked_names(lock: RuntimeLock, name: str | None, verb: str) -> list[str]:
+    """Resolve a ``--name`` (or all patterns) against the lock, validating each."""
+    if not lock.patterns:
+        raise PatternError(f"no patterns to {verb} in {lock.path.parent}")
+    names = [name] if name else list(lock.patterns)
+    for pattern_name in names:
+        if pattern_name not in lock.patterns:
+            raise PatternError(f"pattern {pattern_name!r} not in lock")
+    return names
+
+
+def _revendor(
+    instance_dir: Path,
+    name: str,
+    version: str | None,
+    source: str,
+    old_files: set[str],
+    extra_libraries: dict[str, str] | None,
+) -> tuple[str, str, dict[str, str]]:
+    """Re-fetch an already-locked pattern and rewrite its files in place.
+
+    The single fetch path shared by update and restore, so they can never
+    diverge on how a recorded ``source`` is resolved. ``source`` (a lock label
+    or an explicit override) is normalised to a fetchable URI inside
+    ``_do_vendor``; files dropped relative to ``old_files`` are pruned. Returns
+    the ``(label, version, files)`` the caller records — restore discards it and
+    leaves the lock untouched, since its rewritten bytes reproduce the pin.
+    """
+    ref = PatternRef(name=name, version=version)
+    label, resolved_version, files = _do_vendor(
+        ref, instance_dir, source, extra_libraries
+    )
+    _prune_orphans(_config_dir(instance_dir), old_files - set(files))
+    return label, resolved_version, files
+
+
 def update(
     name: str | None,
     instance_dir: Path,
@@ -142,24 +185,16 @@ def update(
 ) -> None:
     """Re-vendor one (or all) patterns, optionally moving the pinned version."""
     lock = RuntimeLock(_lock_path(instance_dir))
-    if not lock.patterns:
-        raise PatternError(f"no patterns to update in {instance_dir}")
-    names = [name] if name else list(lock.patterns)
-    for pattern_name in names:
-        if pattern_name not in lock.patterns:
-            raise PatternError(f"pattern {pattern_name!r} not in lock")
+    for pattern_name in _locked_names(lock, name, "update"):
         existing = lock.patterns[pattern_name]
-        old_files = set(existing.files)
-        new_version = version or existing.version
-        ref = PatternRef(name=pattern_name, version=new_version)
-        # ``existing.source`` is the lock *label* (scheme-stripped by
-        # ``source_label``); map it back to a fetchable URI, exactly as restore
-        # does, so a github source clones over https rather than as a local path.
-        source = source_override or _source_uri(existing.source, extra_libraries)
-        label, resolved_version, files = _do_vendor(
-            ref, instance_dir, source, extra_libraries
+        label, resolved_version, files = _revendor(
+            instance_dir,
+            pattern_name,
+            version or existing.version,
+            source_override or existing.source,
+            set(existing.files),
+            extra_libraries,
         )
-        _prune_orphans(_config_dir(instance_dir), old_files - set(files))
         lock.set_pattern(pattern_name, resolved_version, label, files)
     lock.save()
     generate_instance_schema(instance_dir)
@@ -172,34 +207,25 @@ def restore(
 ) -> None:
     """Revert vendored files to the pinned version recorded in the lock."""
     lock = RuntimeLock(_lock_path(instance_dir))
-    if not lock.patterns:
-        raise PatternError(f"no patterns to restore in {instance_dir}")
-    names = [name] if name else list(lock.patterns)
-    config_dir = _config_dir(instance_dir)
-    for pattern_name in names:
-        if pattern_name not in lock.patterns:
-            raise PatternError(f"pattern {pattern_name!r} not in lock")
+    for pattern_name in _locked_names(lock, name, "restore"):
         entry = lock.patterns[pattern_name]
-        old_files = set(entry.files)
-        ref = PatternRef(name=pattern_name, version=entry.version)
-        with tempfile.TemporaryDirectory() as tmp:
-            pattern_dir = fetch_pattern(
-                _source_uri(entry.source, extra_libraries),
-                ref.name,
-                ref.version,
-                Path(tmp),
-            )
-            files = _vendor_files(pattern_dir, config_dir, entry.source, entry.version)
-        _prune_orphans(config_dir, old_files - set(files))
+        _revendor(
+            instance_dir,
+            pattern_name,
+            entry.version,
+            entry.source,
+            set(entry.files),
+            extra_libraries,
+        )
     generate_instance_schema(instance_dir)
 
 
 def _source_uri(source: str, extra_libraries: dict[str, str] | None) -> str:
     """Map a recorded lock ``source`` label back to a fetchable URI.
 
-    Used by both update and restore: the lock stores the scheme-stripped label
-    (``source_label``), so a github source must be turned back into an https URL
-    before it is handed to ``git clone``.
+    The lock stores the scheme-stripped label (``source_label``), so a github
+    source must be turned back into an https URL before it is handed to
+    ``git clone``. Idempotent on a source that is already a full URI or path.
     """
     from .sources import library_registry
 

--- a/src/ibek/pattern_cmds/vendor.py
+++ b/src/ibek/pattern_cmds/vendor.py
@@ -152,8 +152,12 @@ def update(
         old_files = set(existing.files)
         new_version = version or existing.version
         ref = PatternRef(name=pattern_name, version=new_version)
+        # ``existing.source`` is the lock *label* (scheme-stripped by
+        # ``source_label``); map it back to a fetchable URI, exactly as restore
+        # does, so a github source clones over https rather than as a local path.
+        source = source_override or _source_uri(existing.source, extra_libraries)
         label, resolved_version, files = _do_vendor(
-            ref, instance_dir, source_override or existing.source, extra_libraries
+            ref, instance_dir, source, extra_libraries
         )
         _prune_orphans(_config_dir(instance_dir), old_files - set(files))
         lock.set_pattern(pattern_name, resolved_version, label, files)
@@ -180,7 +184,7 @@ def restore(
         ref = PatternRef(name=pattern_name, version=entry.version)
         with tempfile.TemporaryDirectory() as tmp:
             pattern_dir = fetch_pattern(
-                _restore_uri(entry.source, extra_libraries),
+                _source_uri(entry.source, extra_libraries),
                 ref.name,
                 ref.version,
                 Path(tmp),
@@ -190,8 +194,13 @@ def restore(
     generate_instance_schema(instance_dir)
 
 
-def _restore_uri(source: str, extra_libraries: dict[str, str] | None) -> str:
-    """Map a recorded lock ``source`` label back to a fetchable URI."""
+def _source_uri(source: str, extra_libraries: dict[str, str] | None) -> str:
+    """Map a recorded lock ``source`` label back to a fetchable URI.
+
+    Used by both update and restore: the lock stores the scheme-stripped label
+    (``source_label``), so a github source must be turned back into an https URL
+    before it is handed to ``git clone``.
+    """
     from .sources import library_registry
 
     for uri in library_registry(extra_libraries).values():

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -226,6 +226,41 @@ def test_restore_reverts_local_edit(tmp_path: Path, library: Path):
     assert "getX" in proto.read_text()
 
 
+def test_update_reconstructs_scheme_for_github_lock_label(
+    tmp_path: Path, library: Path, mocker
+):
+    """update must resolve the scheme-stripped lock label back to an https URI.
+
+    The lock records ``source`` via ``source_label`` (scheme stripped), so a
+    github source is stored as ``github.com/org/repo``. Re-vendoring with no
+    explicit --source must hand ``git clone`` a real ``https://`` URL, not the
+    bare label (which git would treat as a non-existent local path). Restore
+    already did this; this guards update against regressing the asymmetry.
+    """
+    instance = make_instance(tmp_path)
+    vendor.add("mydevice@1.0.0", instance, source_override=str(library))
+    # rewrite the lock to look as if it had been vendored from github
+    lock = RuntimeLock(instance / RUNTIME_LOCK_NAME)
+    lock.patterns[
+        "mydevice"
+    ].source = "github.com/epics-containers/ibek-runtime-streamdevice"
+    lock.save()
+
+    # capture the URI update hands to the fetcher; serve files from the local lib
+    captured: dict[str, str] = {}
+
+    def fake_fetch(uri: str, name: str, version, dest: Path) -> Path:
+        captured["uri"] = uri
+        return library / name
+
+    mocker.patch.object(vendor, "fetch_pattern", side_effect=fake_fetch)
+
+    vendor.update("mydevice", instance)
+    assert captured["uri"] == (
+        "https://github.com/epics-containers/ibek-runtime-streamdevice"
+    )
+
+
 # --------------------------------------------------------------------------- #
 # qualified-name parsing
 # --------------------------------------------------------------------------- #

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -226,16 +226,18 @@ def test_restore_reverts_local_edit(tmp_path: Path, library: Path):
     assert "getX" in proto.read_text()
 
 
-def test_update_reconstructs_scheme_for_github_lock_label(
-    tmp_path: Path, library: Path, mocker
+@pytest.mark.parametrize("operation", [vendor.update, vendor.restore])
+def test_revendor_reconstructs_scheme_for_github_lock_label(
+    tmp_path: Path, library: Path, mocker, operation
 ):
-    """update must resolve the scheme-stripped lock label back to an https URI.
+    """update *and* restore must resolve a scheme-stripped lock label to https.
 
     The lock records ``source`` via ``source_label`` (scheme stripped), so a
     github source is stored as ``github.com/org/repo``. Re-vendoring with no
     explicit --source must hand ``git clone`` a real ``https://`` URL, not the
-    bare label (which git would treat as a non-existent local path). Restore
-    already did this; this guards update against regressing the asymmetry.
+    bare label (which git would treat as a non-existent local path). Both verbs
+    share ``_do_vendor``, so both are exercised here — the original bug was that
+    only restore normalised the label while update cloned it raw.
     """
     instance = make_instance(tmp_path)
     vendor.add("mydevice@1.0.0", instance, source_override=str(library))
@@ -246,7 +248,7 @@ def test_update_reconstructs_scheme_for_github_lock_label(
     ].source = "github.com/epics-containers/ibek-runtime-streamdevice"
     lock.save()
 
-    # capture the URI update hands to the fetcher; serve files from the local lib
+    # capture the URI handed to the fetcher; serve files from the local lib
     captured: dict[str, str] = {}
 
     def fake_fetch(uri: str, name: str, version, dest: Path) -> Path:
@@ -255,7 +257,7 @@ def test_update_reconstructs_scheme_for_github_lock_label(
 
     mocker.patch.object(vendor, "fetch_pattern", side_effect=fake_fetch)
 
-    vendor.update("mydevice", instance)
+    operation("mydevice", instance)
     assert captured["uri"] == (
         "https://github.com/epics-containers/ibek-runtime-streamdevice"
     )


### PR DESCRIPTION
Two related fixes to `ibek pattern update`/`restore`.

## 1. `--name` is a filter option, not a leading positional

`name` was a leading positional on `update`/`restore`, so the common "whole lock" case forced an empty positional: `ibek pattern restore "" services/<instance>`. `name` is a *filter*; every subcommand operates on an instance. Moved it to `--name/-n` (shared `NameOpt`, alongside the existing `--version`/`--source`), so `instance` is the sole positional on update/restore/check/schema. `add` keeps its required `NAME` positional.

```
ibek pattern restore services/<instance>                 # all patterns
ibek pattern restore services/<instance> -n lakeshore340
ibek pattern update  services/<instance> -n lakeshore340 -v 1.2.0
```

## 2. `update` failed to resolve a github lock label to a fetchable URI

The lock records `source` via `source_label`, which strips the scheme — a github source is stored as `github.com/org/repo`. `restore` mapped that label back to an https URL (`_restore_uri`); `update` passed the bare label straight to `git clone`, which read it as a non-existent local path:

```
could not resolve pattern 'lakeshore340': failed to clone
github.com/epics-containers/ibek-runtime-streamdevice@0.1.0-beta.1:
fatal: repository '...' does not exist
```

Renamed `_restore_uri` -> `_source_uri` (now shared) and routed `update`'s lock source through it. Both commands now fetch a github source over https. (Note both `update` *and* `restore` re-clone the pattern library at the pinned version and re-stamp — the lock hashes are integrity-check data, not a content store; restore is not an offline operation.)

## Compatibility / verification

- CLI-surface + internal-URI only — `vendor.update`/`vendor.restore` *function* signatures unchanged.
- Automation (`ci_verify.sh`, services-template pre-commit) only ever calls `check`/`schema` with an instance positional -> unaffected.
- `ruff check`/`format`: clean. `pytest tests/test_pattern.py`: 26 passed.
- New regression test rewrites a lock to a github label and asserts `update` hands `fetch_pattern` the https URL — verified to fail on the pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--name` / `-n` option to target a single pattern for both update and restore commands.
* **Bug Fixes**
  * Improved update/restore vendoring so saved lock sources are consistently normalized for re-fetching.
  * Refinement to how GitHub-based lock labels are reconstructed into fetchable `https://` URIs.
* **Tests**
  * Added coverage ensuring GitHub lock labels are normalized correctly for both update and restore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->